### PR TITLE
refactor(api): show raw asynq payloads and errors

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -416,7 +416,6 @@ en:
       elapsed: Elapsed
       empty: No data
       error: Last error
-      error_detail_redacted: "[Error detail redacted because it may contain sensitive data]"
       failed: Failed
       failed_total: Failed total
       filter: Filter
@@ -443,15 +442,11 @@ en:
       next: Next
       next_process_at: Next attempt
       no_messages: No messages
-      non_json_payload: "[non-JSON payload: %d bytes]"
       orphaned: Orphaned
       overview: Overview
       page_of: Page %d · %d tasks
       pagination: Pagination
       payload: Payload
-      payload_omitted: "[payload omitted: %d bytes]"
-      payload_shape_omitted: "[scalar or array payload omitted: %d bytes]"
-      payload_unavailable: "[payload unavailable: %d bytes]"
       pending: Pending
       queue: Queue
       queues: Queues
@@ -461,7 +456,7 @@ en:
       relation: Relation
       retries: Retries
       retry: Retry
-      safe_preview: Redacted preview
+      raw_payload: Raw payload
       scheduled: Scheduled
       servers: Servers and running tasks
       sent_at: Sent at

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -409,7 +409,6 @@ ja:
       elapsed: 経過時間
       empty: データはありません
       error: 最終エラー
-      error_detail_redacted: "[機密情報を含む可能性があるためエラー詳細を秘匿しました]"
       failed: 失敗
       failed_total: 累計失敗
       filter: 絞り込み
@@ -436,15 +435,11 @@ ja:
       next: 次へ
       next_process_at: 次回実行
       no_messages: メッセージはありません
-      non_json_payload: "[JSONではないペイロード: %dバイト]"
       orphaned: 孤立
       overview: 概要
       page_of: "%dページ · 全%d件"
       pagination: ページネーション
       payload: ペイロード
-      payload_omitted: "[ペイロードを省略しました: %dバイト]"
-      payload_shape_omitted: "[スカラーまたは配列のペイロードを省略しました: %dバイト]"
-      payload_unavailable: "[ペイロードを表示できません: %dバイト]"
       pending: 待機中
       queue: キュー
       queues: キュー
@@ -454,7 +449,7 @@ ja:
       relation: リレーション
       retries: 再試行回数
       retry: 再試行
-      safe_preview: 秘匿済みプレビュー
+      raw_payload: 生のペイロード
       scheduled: 予定
       servers: サーバーと実行中タスク
       sent_at: 送信日時

--- a/internal/paon/api/admin_asynq.go
+++ b/internal/paon/api/admin_asynq.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"html"
@@ -13,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/hibiken/asynq"
 	"github.com/labstack/echo/v5"
@@ -21,11 +18,9 @@ import (
 )
 
 const (
-	asynqHistoryDays       = 90
-	asynqTaskPageSize      = 50
-	asynqTaskMaxPage       = 200
-	asynqPayloadDecodeMax  = 64 * 1024
-	asynqPayloadPreviewMax = 2048
+	asynqHistoryDays  = 90
+	asynqTaskPageSize = 50
+	asynqTaskMaxPage  = 200
 )
 
 var errUnknownAsynqQueue = errors.New("unknown asynq queue")
@@ -142,25 +137,25 @@ type asynqDashboardData struct {
 }
 
 type asynqTaskView struct {
-	ID             string
-	Queue          string
-	DisplayQueue   string
-	Type           string
-	State          string
-	Retried        int
-	MaxRetry       int
-	LastError      string
-	LastFailedAt   time.Time
-	NextProcessAt  time.Time
-	Deadline       time.Time
-	StartedAt      time.Time
-	Elapsed        time.Duration
-	IsOrphaned     bool
-	PayloadBytes   int
-	PayloadPreview string
-	WorkerHost     string
-	WorkerPID      int
-	Sequence       int
+	ID            string
+	Queue         string
+	DisplayQueue  string
+	Type          string
+	State         string
+	Retried       int
+	MaxRetry      int
+	LastError     string
+	LastFailedAt  time.Time
+	NextProcessAt time.Time
+	Deadline      time.Time
+	StartedAt     time.Time
+	Elapsed       time.Duration
+	IsOrphaned    bool
+	PayloadBytes  int
+	RawPayload    string
+	WorkerHost    string
+	WorkerPID     int
+	Sequence      int
 }
 
 type asynqTaskPage struct {
@@ -212,138 +207,6 @@ func asynqDuration(value time.Duration) string {
 		return "<1s"
 	}
 	return value.Round(time.Second).String()
-}
-
-func asynqSafeText(value string, limit int) string {
-	value = strings.Map(func(r rune) rune {
-		if unicode.IsControl(r) && r != '\n' && r != '\t' {
-			return -1
-		}
-		return r
-	}, value)
-	value = strings.TrimSpace(value)
-	if limit > 0 && len(value) > limit {
-		value = value[:limit] + "…"
-	}
-	return value
-}
-
-func asynqLocale(locales ...string) string {
-	if len(locales) > 0 && strings.TrimSpace(locales[0]) != "" {
-		return locales[0]
-	}
-	return "en"
-}
-
-func asynqErrorPreview(value string, locales ...string) string {
-	value = asynqSafeText(value, 1000)
-	lower := strings.ToLower(value)
-	compact := strings.NewReplacer("_", "", "-", "", " ", "").Replace(lower)
-	redacted := adminT(asynqLocale(locales...), "admin.devops.error_detail_redacted", "[Error detail redacted because it may contain sensitive data]")
-	for _, marker := range []string{"token", "password", "secret", "privatekey", "apikey", "authorization", "credential", "cookie", "signature"} {
-		if strings.Contains(compact, marker) {
-			return redacted
-		}
-	}
-	for _, marker := range []string{`"body"`, "body=", "body:", `"content"`, "content=", `"headers"`, `"htmlbody"`, `"textbody"`, `"mailmessage"`, `"recipient"`, `"email"`, `"subject"`, `"message":`, "message="} {
-		if strings.Contains(lower, marker) {
-			return redacted
-		}
-	}
-	return value
-}
-
-func asynqPayloadKeySensitive(key string) bool {
-	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(key), "-", "_"))
-	compact := strings.ReplaceAll(normalized, "_", "")
-	for _, fragment := range []string{"token", "password", "secret", "privatekey", "apikey", "credential", "authorization", "cookie", "signature", "encrypted"} {
-		if strings.Contains(compact, fragment) {
-			return true
-		}
-	}
-	switch compact {
-	case "body", "htmlbody", "textbody", "rawbody", "content", "json", "message", "mailmessage", "headers", "recipient", "recipients", "to", "email", "address", "subject":
-		return true
-	default:
-		return false
-	}
-}
-
-func asynqSanitizePayloadValue(value any, depth int) any {
-	if depth >= 6 {
-		return "[truncated]"
-	}
-	switch value := value.(type) {
-	case map[string]any:
-		keys := make([]string, 0, len(value))
-		for key := range value {
-			keys = append(keys, key)
-		}
-		sort.Strings(keys)
-		if len(keys) > 30 {
-			keys = keys[:30]
-		}
-		out := make(map[string]any, len(keys)+1)
-		for _, key := range keys {
-			if asynqPayloadKeySensitive(key) {
-				out[key] = "[REDACTED]"
-				continue
-			}
-			out[key] = asynqSanitizePayloadValue(value[key], depth+1)
-		}
-		if len(value) > len(keys) {
-			out["_truncated"] = true
-		}
-		return out
-	case []any:
-		limit := len(value)
-		if limit > 10 {
-			limit = 10
-		}
-		out := make([]any, 0, limit+1)
-		for _, item := range value[:limit] {
-			out = append(out, asynqSanitizePayloadValue(item, depth+1))
-		}
-		if len(value) > limit {
-			out = append(out, "[truncated]")
-		}
-		return out
-	case string:
-		return asynqSafeText(value, 256)
-	default:
-		return value
-	}
-}
-
-func asynqPayloadPreview(payload []byte, locales ...string) string {
-	if len(payload) == 0 {
-		return ""
-	}
-	locale := asynqLocale(locales...)
-	if len(payload) > asynqPayloadDecodeMax {
-		return fmt.Sprintf(adminT(locale, "admin.devops.payload_omitted", "[payload omitted: %d bytes]"), len(payload))
-	}
-	decoder := json.NewDecoder(bytes.NewReader(payload))
-	decoder.UseNumber()
-	var value any
-	if err := decoder.Decode(&value); err != nil {
-		return fmt.Sprintf(adminT(locale, "admin.devops.non_json_payload", "[non-JSON payload: %d bytes]"), len(payload))
-	}
-	if _, ok := value.(map[string]any); !ok {
-		return fmt.Sprintf(adminT(locale, "admin.devops.payload_shape_omitted", "[scalar or array payload omitted: %d bytes]"), len(payload))
-	}
-	var extra any
-	if err := decoder.Decode(&extra); err == nil {
-		return fmt.Sprintf(adminT(locale, "admin.devops.non_json_payload", "[non-JSON payload: %d bytes]"), len(payload))
-	}
-	encoded, err := json.MarshalIndent(asynqSanitizePayloadValue(value, 0), "", "  ")
-	if err != nil {
-		return fmt.Sprintf(adminT(locale, "admin.devops.payload_unavailable", "[payload unavailable: %d bytes]"), len(payload))
-	}
-	if len(encoded) > asynqPayloadPreviewMax {
-		return string(encoded[:asynqPayloadPreviewMax]) + "\n…"
-	}
-	return string(encoded)
 }
 
 func asynqUnavailableSnapshot(locale string, err error) asynqDashboardSnapshot {
@@ -822,8 +685,7 @@ func asynqResolveQueueFilter(s *Server, data *asynqDashboardData, filter string)
 	return match
 }
 
-func (s *Server) asynqTaskPage(data *asynqDashboardData, state string, queueFilter string, page int, locales ...string) (asynqTaskPage, error) {
-	locale := asynqLocale(locales...)
+func (s *Server) asynqTaskPage(data *asynqDashboardData, state string, queueFilter string, page int) (asynqTaskPage, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -899,23 +761,23 @@ func (s *Server) asynqTaskPage(data *asynqDashboardData, state string, queueFilt
 				nextProcessAt = time.Time{}
 			}
 			view := asynqTaskView{
-				ID:             task.ID,
-				Queue:          queue,
-				DisplayQueue:   asynqLogicalQueueName(s.cfg.RedisNamespace, queue),
-				Type:           task.Type,
-				State:          state,
-				Retried:        task.Retried,
-				MaxRetry:       task.MaxRetry,
-				LastError:      asynqErrorPreview(task.LastErr, locale),
-				LastFailedAt:   task.LastFailedAt,
-				NextProcessAt:  nextProcessAt,
-				Deadline:       deadline,
-				StartedAt:      startedAt,
-				Elapsed:        elapsed,
-				IsOrphaned:     task.IsOrphaned,
-				PayloadBytes:   len(task.Payload),
-				PayloadPreview: asynqPayloadPreview(task.Payload, locale),
-				Sequence:       sequence,
+				ID:            task.ID,
+				Queue:         queue,
+				DisplayQueue:  asynqLogicalQueueName(s.cfg.RedisNamespace, queue),
+				Type:          task.Type,
+				State:         state,
+				Retried:       task.Retried,
+				MaxRetry:      task.MaxRetry,
+				LastError:     task.LastErr,
+				LastFailedAt:  task.LastFailedAt,
+				NextProcessAt: nextProcessAt,
+				Deadline:      deadline,
+				StartedAt:     startedAt,
+				Elapsed:       elapsed,
+				IsOrphaned:    task.IsOrphaned,
+				PayloadBytes:  len(task.Payload),
+				RawPayload:    string(task.Payload),
+				Sequence:      sequence,
 			}
 			if server != nil {
 				view.WorkerHost = server.Host
@@ -1052,7 +914,7 @@ func (s *Server) sidekiqPage(c *echo.Context) error {
 	}
 	var taskPage *asynqTaskPage
 	if dashboardAvailable && (view == "active" || view == "pending" || view == "retry" || view == "scheduled" || view == "archived") {
-		page, pageErr := s.asynqTaskPage(data, view, c.QueryParam("queue"), asynqPageNumber(c), locale)
+		page, pageErr := s.asynqTaskPage(data, view, c.QueryParam("queue"), asynqPageNumber(c))
 		if pageErr != nil {
 			if errors.Is(pageErr, errUnknownAsynqQueue) {
 				return echo.NewHTTPError(http.StatusBadRequest, adminT(locale, "admin.devops.unknown_queue", "Unknown queue"))
@@ -1338,8 +1200,8 @@ func asynqTaskRowsHTML(page *asynqTaskPage, locale string) string {
 			lastError = `<details><summary>` + asynqHTMLAttr(adminT(locale, "admin.devops.details", "Details")) + `</summary><pre>` + asynqHTMLAttr(task.LastError) + `</pre></details>`
 		}
 		payload := `<small>` + strconv.Itoa(task.PayloadBytes) + ` ` + asynqHTMLAttr(adminT(locale, "admin.devops.bytes", "bytes")) + `</small>`
-		if task.PayloadPreview != "" {
-			payload += `<details><summary>` + asynqHTMLAttr(adminT(locale, "admin.devops.safe_preview", "Redacted preview")) + `</summary><pre>` + asynqHTMLAttr(task.PayloadPreview) + `</pre></details>`
+		if task.RawPayload != "" {
+			payload += `<details><summary>` + asynqHTMLAttr(adminT(locale, "admin.devops.raw_payload", "Raw payload")) + `</summary><pre>` + asynqHTMLAttr(task.RawPayload) + `</pre></details>`
 		}
 		body.WriteString(`<tr><td><code>` + asynqHTMLAttr(task.ID) + `</code>` + orphan + `</td><td><strong>` + asynqHTMLAttr(task.DisplayQueue) + `</strong>`)
 		if task.Queue != task.DisplayQueue {

--- a/internal/paon/api/admin_asynq_test.go
+++ b/internal/paon/api/admin_asynq_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -319,56 +318,45 @@ func TestCollectAsynqDashboardPropagatesInspectorFailuresAndStatsUses503(t *test
 	}
 }
 
-func TestAsynqPayloadPreviewRedactsAndBoundsUntrustedPayloads(t *testing.T) {
-	payload := []byte(`{
-  "account_id": 42,
-  "old_private_key": "PRIVATE-LEAK",
-  "privateKey": "CAMEL-PRIVATE-LEAK",
-  "apiKey": "API-KEY-LEAK",
-  "access-token": "TOKEN-LEAK",
-  "nested": {"password": "PASSWORD-LEAK", "safe": "visible"},
-  "headers": {"Authorization": "BEARER-LEAK"},
-  "content": "MAIL-BODY-LEAK",
-  "htmlBody": "HTML-BODY-LEAK",
-  "mailMessage": "MAIL-MESSAGE-LEAK"
-}`)
-	preview := asynqPayloadPreview(payload)
-	for _, secret := range []string{"PRIVATE-LEAK", "CAMEL-PRIVATE-LEAK", "API-KEY-LEAK", "TOKEN-LEAK", "PASSWORD-LEAK", "BEARER-LEAK", "MAIL-BODY-LEAK", "HTML-BODY-LEAK", "MAIL-MESSAGE-LEAK"} {
-		if strings.Contains(preview, secret) {
-			t.Fatalf("payload preview leaked %q: %s", secret, preview)
-		}
+func TestAsynqTaskDetailsShowCompleteRawPayloadAndErrorWithHTMLEscaping(t *testing.T) {
+	payload := []byte(`{"token":"ADMIN-TOKEN","body":"</pre><script>alert('payload')</script>","large":"` + strings.Repeat("x", 70*1024) + `"}`)
+	lastError := `delivery failed: privateKey=ERROR-SECRET </pre><script>alert('error')</script> ` + strings.Repeat("e", 2_000)
+	inspector := &fakeAsynqInspectorClient{
+		tasks: map[string]map[string][]*asynq.TaskInfo{
+			"pending": {"default": {{ID: "raw-task", Queue: "default", Type: "raw", Payload: payload, LastErr: lastError}}},
+		},
+		listErr: map[string]error{},
 	}
-	for _, want := range []string{`"account_id": 42`, `"safe": "visible"`, "[REDACTED]"} {
-		if !strings.Contains(preview, want) {
-			t.Fatalf("payload preview missing %q: %s", want, preview)
-		}
+	server := &Server{asynqInspector: inspector}
+	data := &asynqDashboardData{
+		QueueInfos:  map[string]*asynq.QueueInfo{"default": {Queue: "default", Pending: 1}},
+		ActiveTasks: map[string][]*asynq.TaskInfo{}, WorkerByTask: map[string]*asynq.WorkerInfo{}, ServerByTask: map[string]*asynq.ServerInfo{},
 	}
-
-	wide := make(map[string]any)
-	for i := 0; i < 30; i++ {
-		wide[fmt.Sprintf("field_%02d", i)] = strings.Repeat("x", 256)
-	}
-	encoded, err := json.Marshal(wide)
+	page, err := server.asynqTaskPage(data, "pending", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	truncated := asynqPayloadPreview(encoded)
-	if !strings.HasSuffix(truncated, "\n…") || len(truncated) > asynqPayloadPreviewMax+4 {
-		t.Fatalf("bounded payload preview length/suffix = %d %q", len(truncated), truncated)
+	if len(page.Tasks) != 1 {
+		t.Fatalf("task count = %d, want 1", len(page.Tasks))
+	}
+	task := page.Tasks[0]
+	if task.RawPayload != string(payload) {
+		t.Fatalf("raw payload changed: got %d bytes, want %d", len(task.RawPayload), len(payload))
+	}
+	if task.LastError != lastError {
+		t.Fatalf("last error changed: got %d bytes, want %d", len(task.LastError), len(lastError))
 	}
 
-	oversized := []byte(`{"safe":"` + strings.Repeat("secret-payload", asynqPayloadDecodeMax/len("secret-payload")+2) + `"}`)
-	if got := asynqPayloadPreview(oversized); !strings.Contains(got, "payload omitted") || strings.Contains(got, "secret-payload") {
-		t.Fatalf("oversized payload preview = %q", got)
+	rows := asynqTaskRowsHTML(&page, "en")
+	for _, want := range []string{"ADMIN-TOKEN", "ERROR-SECRET", "Raw payload", "&lt;/pre&gt;&lt;script&gt;alert(&#39;payload&#39;)&lt;/script&gt;", "&lt;/pre&gt;&lt;script&gt;alert(&#39;error&#39;)&lt;/script&gt;"} {
+		if !strings.Contains(rows, want) {
+			t.Fatalf("task HTML missing %q", want)
+		}
 	}
-	if got := asynqPayloadPreview([]byte("not-json-secret")); got != "[non-JSON payload: 15 bytes]" {
-		t.Fatalf("non-JSON payload preview = %q", got)
-	}
-	if got := asynqPayloadPreview([]byte(`"TOP-LEVEL-SECRET"`)); strings.Contains(got, "TOP-LEVEL-SECRET") || !strings.Contains(got, "omitted") {
-		t.Fatalf("top-level scalar payload preview = %q", got)
-	}
-	if got := asynqErrorPreview(`delivery failed: privateKey=ERROR-SECRET`); strings.Contains(got, "ERROR-SECRET") || !strings.Contains(strings.ToLower(got), "redacted") {
-		t.Fatalf("error preview = %q", got)
+	for _, unwanted := range []string{"<script>", "[REDACTED]", "payload omitted", "error detail redacted"} {
+		if strings.Contains(rows, unwanted) {
+			t.Fatalf("task HTML unexpectedly contains %q", unwanted)
+		}
 	}
 }
 


### PR DESCRIPTION
Drop payload sanitization and error redaction from the asynq admin dashboard and render raw task payloads / last errors verbatim with HTML escaping to prevent XSS.

- Rename PayloadPreview to RawPayload and store task.Payload as-is.
- Replace asynqErrorPreview, asynqSanitizePayloadValue and related helpers with the existing asynqHTMLAttr escape.
- Remove unused imports (bytes, encoding/json, sort, strings, unicode) and payload size constants.
- Refresh test to verify HTML escaping and that raw text is preserved.
- Remove obsolete locale keys (error_detail_redacted, non_json_payload, payload_omitted, payload_shape_omitted, payload_unavailable, safe_preview) and add raw_payload.