### PR TITLE
feat(api): prefix remote account avatar/header paths with cache/

### DIFF
--- a/internal/paon/api/account_rss.go
+++ b/internal/paon/api/account_rss.go
@@ -409,7 +409,7 @@ func accountRSSLocalUsernameAndDomain(cfg config.Config, account models.Account)
 
 func accountRSSAvatarURL(cfg config.Config, account models.Account) string {
 	if account.AvatarFileName.Valid && account.AvatarFileName.String != "" {
-		return cfg.SystemAssetURL("accounts/avatars/" + strings.ReplaceAll(mediaPaperclipIDPartition(account.ID), "\\", "/") + "/original/" + url.PathEscape(account.AvatarFileName.String))
+		return cfg.SystemAssetURL(accountImageAssetPath(account, "avatar", "original", account.AvatarFileName.String))
 	}
 	return cfg.BaseURL() + "/avatars/original/missing.png"
 }

--- a/internal/paon/api/activitypub.go
+++ b/internal/paon/api/activitypub.go
@@ -1577,11 +1577,11 @@ func activityPubAccountImage(s *Server, account models.Account) map[string]any {
 }
 
 func activityPubAccountAvatarURL(s *Server, account models.Account) string {
-	return s.cfg.SystemAssetURL("accounts/avatars/" + mediaPaperclipIDPartition(account.ID) + "/original/" + url.PathEscape(account.AvatarFileName.String))
+	return s.cfg.SystemAssetURL(accountImageAssetPath(account, "avatar", "original", account.AvatarFileName.String))
 }
 
 func activityPubAccountHeaderURL(s *Server, account models.Account) string {
-	return s.cfg.SystemAssetURL("accounts/headers/" + mediaPaperclipIDPartition(account.ID) + "/original/" + url.PathEscape(account.HeaderFileName.String))
+	return s.cfg.SystemAssetURL(accountImageAssetPath(account, "header", "original", account.HeaderFileName.String))
 }
 
 func activityPubAccountImageObject(contentType string, value string) map[string]any {

--- a/internal/paon/api/admin_accounts_web.go
+++ b/internal/paon/api/admin_accounts_web.go
@@ -1316,7 +1316,7 @@ func adminAccountModerationNoteHTML(note models.AccountModerationNote, locale st
 
 func adminAccountModerationNoteAvatarURL(cfg config.Config, account models.Account) string {
 	if account.AvatarFileName.Valid && strings.TrimSpace(account.AvatarFileName.String) != "" && account.ID != 0 {
-		return adminAccountPaperclipAssetURL(cfg, "accounts/avatars/"+adminPaperclipIDPartition(account.ID)+"/original/"+url.PathEscape(account.AvatarFileName.String))
+		return adminAccountPaperclipAssetURL(cfg, accountImageAssetPath(account, "avatar", "original", account.AvatarFileName.String))
 	}
 	if account.AvatarRemoteURL.Valid && strings.TrimSpace(account.AvatarRemoteURL.String) != "" {
 		return account.AvatarRemoteURL.String

--- a/internal/paon/api/backups.go
+++ b/internal/paon/api/backups.go
@@ -398,7 +398,8 @@ func (s *Server) backupAccountImageArchiveEntry(account models.Account, kind str
 	if filename == "" {
 		return backupArchiveEntry{}, false, nil
 	}
-	path := s.accountImagePath(account.ID, kind, filename)
+	cachePrefix := accountImageUsesCachePrefix(account, kind)
+	path := s.accountImagePathStyleWithCachePrefix(account.ID, kind, "original", filename, cachePrefix)
 	ext := filepath.Ext(filename)
 	entryName := kind
 	if kind == "avatar" {
@@ -406,7 +407,7 @@ func (s *Server) backupAccountImageArchiveEntry(account models.Account, kind str
 	} else {
 		entryName = "header"
 	}
-	return s.backupPaperclipArchiveEntry(entryName+ext, path, accountImageObjectKey(account.ID, kind, "original", filename))
+	return s.backupPaperclipArchiveEntry(entryName+ext, path, accountImageObjectKeyForAccount(account, kind, "original", filename))
 }
 
 func backupActivityImageObject(mediaType string, name string) map[string]any {

--- a/internal/paon/api/cache_buster.go
+++ b/internal/paon/api/cache_buster.go
@@ -28,17 +28,21 @@ func (s *Server) bustAccountImageCache(account models.Account) {
 		return
 	}
 	if account.AvatarFileName.Valid && strings.TrimSpace(account.AvatarFileName.String) != "" {
-		s.bustAccountImageKindCache(account.ID, "avatar", account.AvatarFileName.String, account.AvatarContentType.String)
+		s.bustAccountImageKindCacheWithPrefix(account.ID, "avatar", account.AvatarFileName.String, account.AvatarContentType.String, account.AvatarUsesCachePrefix())
 	}
 	if account.HeaderFileName.Valid && strings.TrimSpace(account.HeaderFileName.String) != "" {
-		s.bustAccountImageKindCache(account.ID, "header", account.HeaderFileName.String, account.HeaderContentType.String)
+		s.bustAccountImageKindCacheWithPrefix(account.ID, "header", account.HeaderFileName.String, account.HeaderContentType.String, account.HeaderUsesCachePrefix())
 	}
 }
 
 func (s *Server) bustAccountImageKindCache(accountID int64, kind string, filename string, contentType string) {
-	s.bustCacheURL(s.cacheBusterAccountImageURL(accountID, kind, "original", filename))
+	s.bustAccountImageKindCacheWithPrefix(accountID, kind, filename, contentType, false)
+}
+
+func (s *Server) bustAccountImageKindCacheWithPrefix(accountID int64, kind string, filename string, contentType string, cachePrefix bool) {
+	s.bustCacheURL(s.cacheBusterAccountImageURLWithPrefix(accountID, kind, "original", filename, cachePrefix))
 	if static := profileImageStaticFilename(filename, contentType); static != "" {
-		s.bustCacheURL(s.cacheBusterAccountImageURL(accountID, kind, "static", static))
+		s.bustCacheURL(s.cacheBusterAccountImageURLWithPrefix(accountID, kind, "static", static, cachePrefix))
 	}
 }
 
@@ -92,11 +96,19 @@ func (s *Server) cacheBusterMediaAttachmentURL(id int64, attachment string, styl
 }
 
 func (s *Server) cacheBusterAccountImageURL(id int64, kind string, style string, filename string) string {
+	return s.cacheBusterAccountImageURLWithPrefix(id, kind, style, filename, false)
+}
+
+func (s *Server) cacheBusterAccountImageURLWithPrefix(id int64, kind string, style string, filename string, cachePrefix bool) string {
 	dir := "avatars"
 	if kind == "header" {
 		dir = "headers"
 	}
-	path := "accounts/" + dir + "/" + strings.ReplaceAll(mediaPaperclipIDPartition(id), "\\", "/") + "/" + style + "/" + url.PathEscape(filename)
+	prefix := ""
+	if cachePrefix {
+		prefix = "cache/"
+	}
+	path := prefix + "accounts/" + dir + "/" + strings.ReplaceAll(mediaPaperclipIDPartition(id), "\\", "/") + "/" + style + "/" + url.PathEscape(filename)
 	return s.cacheBusterAssetURL(path)
 }
 

--- a/internal/paon/api/domain_media_cleanup.go
+++ b/internal/paon/api/domain_media_cleanup.go
@@ -233,6 +233,8 @@ func (s *Server) removeAccountLocalImageFiles(accountID int64) {
 	for _, root := range []string{
 		s.cfg.SystemAssetPath("accounts", "avatars", id),
 		s.cfg.SystemAssetPath("accounts", "headers", id),
+		s.cfg.SystemAssetPath("cache", "accounts", "avatars", id),
+		s.cfg.SystemAssetPath("cache", "accounts", "headers", id),
 	} {
 		_ = os.RemoveAll(root)
 	}
@@ -246,7 +248,12 @@ func (s *Server) removeAccountLocalImageFilesForKind(accountID int64, kind strin
 	if kind == "header" {
 		dir = "headers"
 	}
-	_ = os.RemoveAll(s.cfg.SystemAssetPath("accounts", dir, mediaPaperclipIDPartition(accountID)))
+	for _, root := range []string{
+		s.cfg.SystemAssetPath("accounts", dir, mediaPaperclipIDPartition(accountID)),
+		s.cfg.SystemAssetPath("cache", "accounts", dir, mediaPaperclipIDPartition(accountID)),
+	} {
+		_ = os.RemoveAll(root)
+	}
 }
 
 func (s *Server) removeAccountImageObjects(account models.Account) {
@@ -255,12 +262,12 @@ func (s *Server) removeAccountImageObjects(account models.Account) {
 	}
 	s.bustAccountImageCache(account)
 	if account.AvatarFileName.Valid && strings.TrimSpace(account.AvatarFileName.String) != "" {
-		s.deletePaperclipObject(context.Background(), accountImageObjectKey(account.ID, "avatar", "original", account.AvatarFileName.String))
-		s.deletePaperclipObject(context.Background(), accountImageObjectKey(account.ID, "avatar", "static", profileImageStaticFilename(account.AvatarFileName.String, account.AvatarContentType.String)))
+		s.deletePaperclipObject(context.Background(), accountImageObjectKeyForAccount(account, "avatar", "original", account.AvatarFileName.String))
+		s.deletePaperclipObject(context.Background(), accountImageObjectKeyForAccount(account, "avatar", "static", profileImageStaticFilename(account.AvatarFileName.String, account.AvatarContentType.String)))
 	}
 	if account.HeaderFileName.Valid && strings.TrimSpace(account.HeaderFileName.String) != "" {
-		s.deletePaperclipObject(context.Background(), accountImageObjectKey(account.ID, "header", "original", account.HeaderFileName.String))
-		s.deletePaperclipObject(context.Background(), accountImageObjectKey(account.ID, "header", "static", profileImageStaticFilename(account.HeaderFileName.String, account.HeaderContentType.String)))
+		s.deletePaperclipObject(context.Background(), accountImageObjectKeyForAccount(account, "header", "original", account.HeaderFileName.String))
+		s.deletePaperclipObject(context.Background(), accountImageObjectKeyForAccount(account, "header", "static", profileImageStaticFilename(account.HeaderFileName.String, account.HeaderContentType.String)))
 	}
 }
 

--- a/internal/paon/api/embeds.go
+++ b/internal/paon/api/embeds.go
@@ -390,11 +390,14 @@ func statusEmbedAccountAvatarURL(baseURL string, account models.Account) string 
 
 func statusEmbedAccountAvatarURLWithConfig(cfg config.Config, account models.Account) string {
 	baseURL := cfg.BaseURL()
-	if account.AvatarRemoteURL.Valid && strings.TrimSpace(account.AvatarRemoteURL.String) != "" {
+	if account.AvatarRemoteURL.Valid && strings.TrimSpace(account.AvatarRemoteURL.String) != "" && cfg.DisableRemoteMediaCache {
 		return strings.TrimSpace(account.AvatarRemoteURL.String)
 	}
 	if account.AvatarFileName.Valid && strings.TrimSpace(account.AvatarFileName.String) != "" {
-		return cfg.SystemAssetURL("accounts/avatars/" + strings.ReplaceAll(mediaPaperclipIDPartition(account.ID), "\\", "/") + "/original/" + url.PathEscape(account.AvatarFileName.String))
+		return cfg.SystemAssetURL(accountImageAssetPath(account, "avatar", "original", account.AvatarFileName.String))
+	}
+	if account.AvatarRemoteURL.Valid && strings.TrimSpace(account.AvatarRemoteURL.String) != "" {
+		return strings.TrimSpace(account.AvatarRemoteURL.String)
 	}
 	return baseURL + "/avatars/original/missing.png"
 }

--- a/internal/paon/api/profile_credentials.go
+++ b/internal/paon/api/profile_credentials.go
@@ -288,20 +288,32 @@ func (s *Server) storeAccountImageFile(header *multipart.FileHeader, accountID i
 }
 
 func (s *Server) accountImagePath(accountID int64, kind string, filename string) string {
-	return s.accountImagePathStyle(accountID, kind, "original", filename)
+	return s.accountImagePathStyleWithCachePrefix(accountID, kind, "original", filename, false)
 }
 
 func (s *Server) accountImagePathStyle(accountID int64, kind string, style string, filename string) string {
+	return s.accountImagePathStyleWithCachePrefix(accountID, kind, style, filename, false)
+}
+
+func (s *Server) accountImagePathStyleWithCachePrefix(accountID int64, kind string, style string, filename string, cachePrefix bool) string {
 	dir := "avatars"
 	if kind == "header" {
 		dir = "headers"
 	}
-	return s.cfg.SystemAssetPath("accounts", dir, mediaPaperclipIDPartition(accountID), style, filename)
+	parts := []string{"accounts", dir, mediaPaperclipIDPartition(accountID), style, filename}
+	if cachePrefix {
+		parts = append([]string{"cache"}, parts...)
+	}
+	return s.cfg.SystemAssetPath(parts...)
 }
 
 func (s *Server) storeAccountImageStaticStyle(accountID int64, kind string, filename string, originalPath string, contentType string) error {
+	return s.storeAccountImageStaticStyleWithCachePrefix(accountID, kind, filename, originalPath, contentType, false)
+}
+
+func (s *Server) storeAccountImageStaticStyleWithCachePrefix(accountID int64, kind string, filename string, originalPath string, contentType string, cachePrefix bool) error {
 	staticFilename := profileImageStaticFilename(filename, contentType)
-	staticTarget := s.accountImagePathStyle(accountID, kind, "static", staticFilename)
+	staticTarget := s.accountImagePathStyleWithCachePrefix(accountID, kind, "static", staticFilename, cachePrefix)
 	staticContentType := contentType
 	if strings.EqualFold(strings.TrimSpace(strings.Split(contentType, ";")[0]), "image/gif") {
 		staticContentType = "image/png"
@@ -311,7 +323,7 @@ func (s *Server) storeAccountImageStaticStyle(accountID int64, kind string, file
 	} else if err := copyFile(originalPath, staticTarget); err != nil {
 		return err
 	}
-	return s.uploadPaperclipObject(context.Background(), accountImageObjectKey(accountID, kind, "static", staticFilename), staticTarget, staticContentType)
+	return s.uploadPaperclipObject(context.Background(), accountImageObjectKeyWithCachePrefix(accountID, kind, "static", staticFilename, cachePrefix), staticTarget, staticContentType)
 }
 
 func profileImageStaticFilename(filename string, contentType string) string {

--- a/internal/paon/api/remote_account_media.go
+++ b/internal/paon/api/remote_account_media.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -60,7 +61,7 @@ func (s *Server) downloadAndStoreRemoteAccountImage(ctx context.Context, account
 		return err
 	}
 	now := time.Now().UTC()
-	return s.db.WithContext(ctx).Model(&models.Account{}).Where("id = ?", accountID).Updates(profileImageUpdates(kind, filename, contentType, int64(len(data)), now)).Error
+	return s.db.WithContext(ctx).Model(&models.Account{}).Where("id = ?", accountID).Updates(remoteProfileImageUpdates(kind, filename, contentType, int64(len(data)), remoteURL, now)).Error
 }
 
 // resizeAccountImageBuffer applies the Rails avatar (400x400# fill crop) or header
@@ -80,7 +81,7 @@ func resizeAccountImageBuffer(kind string, data []byte, contentType string) ([]b
 // (profile_credentials.go): it writes the original style locally + S3 and writes the
 // static style through the shared Rails-style profile image pipeline.
 func (s *Server) storeAccountImageBytes(accountID int64, kind string, filename string, contentType string, data []byte) error {
-	target := s.accountImagePath(accountID, kind, filename)
+	target := s.accountImagePathStyleWithCachePrefix(accountID, kind, "original", filename, true)
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 		return err
 	}
@@ -88,8 +89,20 @@ func (s *Server) storeAccountImageBytes(accountID int64, kind string, filename s
 		return err
 	}
 	ctx := context.Background()
-	if err := s.uploadPaperclipObject(ctx, accountImageObjectKey(accountID, kind, "original", filename), target, contentType); err != nil {
+	if err := s.uploadPaperclipObject(ctx, accountImageObjectKeyWithCachePrefix(accountID, kind, "original", filename, true), target, contentType); err != nil {
 		return err
 	}
-	return s.storeAccountImageStaticStyle(accountID, kind, filename, target, contentType)
+	return s.storeAccountImageStaticStyleWithCachePrefix(accountID, kind, filename, target, contentType, true)
+}
+
+func remoteProfileImageUpdates(kind string, filename string, contentType string, size int64, remoteURL string, now time.Time) map[string]any {
+	updates := profileImageUpdates(kind, filename, contentType, size, now)
+	if kind == "avatar" {
+		updates["avatar_remote_url"] = sql.NullString{String: remoteURL, Valid: strings.TrimSpace(remoteURL) != ""}
+		updates["avatar_storage_schema_version"] = sql.NullInt64{Int64: 1, Valid: true}
+		return updates
+	}
+	updates["header_remote_url"] = remoteURL
+	updates["header_storage_schema_version"] = sql.NullInt64{Int64: 1, Valid: true}
+	return updates
 }

--- a/internal/paon/api/remote_account_media_test.go
+++ b/internal/paon/api/remote_account_media_test.go
@@ -1,8 +1,13 @@
 package api
 
 import (
+	"database/sql"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/mstdn-plusminus-io/paon/internal/paon/config"
 )
 
 func TestDownloadAndStoreRemoteAccountImageGuardsAndPipeline(t *testing.T) {
@@ -15,11 +20,47 @@ func TestDownloadAndStoreRemoteAccountImageGuardsAndPipeline(t *testing.T) {
 		`fetchRemoteImageMedia(ctx, remoteURL, remoteAccountImageLimit)`,
 		`profileImageContentTypeSupported(contentType)`,
 		`resizeAccountImageBuffer(kind, download.body, contentType)`,
-		`profileImageUpdates(kind, filename, contentType, int64(len(data)), now)`,
+		`remoteProfileImageUpdates(kind, filename, contentType, int64(len(data)), remoteURL, now)`,
 	} {
 		if !functionBodyContains(t, src, "downloadAndStoreRemoteAccountImage", want) {
 			t.Fatalf("downloadAndStoreRemoteAccountImage missing %q", want)
 		}
+	}
+}
+
+func TestRemoteProfileImageUpdatesPreserveRemoteURLAndCacheSchema(t *testing.T) {
+	now := time.Date(2026, 7, 19, 15, 0, 0, 0, time.UTC)
+	avatar := remoteProfileImageUpdates("avatar", "avatar.png", "image/png", 123, "https://remote.example/avatar.png", now)
+	if avatar["avatar_remote_url"] != (sql.NullString{String: "https://remote.example/avatar.png", Valid: true}) {
+		t.Fatalf("avatar remote URL = %#v", avatar["avatar_remote_url"])
+	}
+	if avatar["avatar_storage_schema_version"] != (sql.NullInt64{Int64: 1, Valid: true}) {
+		t.Fatalf("avatar storage schema = %#v", avatar["avatar_storage_schema_version"])
+	}
+
+	header := remoteProfileImageUpdates("header", "header.png", "image/png", 456, "https://remote.example/header.png", now)
+	if header["header_remote_url"] != "https://remote.example/header.png" {
+		t.Fatalf("header remote URL = %#v", header["header_remote_url"])
+	}
+	if header["header_storage_schema_version"] != (sql.NullInt64{Int64: 1, Valid: true}) {
+		t.Fatalf("header storage schema = %#v", header["header_storage_schema_version"])
+	}
+}
+
+func TestStoreRemoteAccountImageUsesRailsCachePrefix(t *testing.T) {
+	root := t.TempDir()
+	s := &Server{cfg: config.Config{PublicDir: root}}
+	if err := s.storeAccountImageBytes(42, "avatar", "avatar.png", "image/png", siteUploadTestPNG(t, 20, 20)); err != nil {
+		t.Fatal(err)
+	}
+	for _, style := range []string{"original", "static"} {
+		path := filepath.Join(root, "system", "cache", "accounts", "avatars", "000", "000", "042", style, "avatar.png")
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("remote avatar %s missing: %v", style, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, "system", "accounts", "avatars", "000", "000", "042", "original", "avatar.png")); !os.IsNotExist(err) {
+		t.Fatalf("remote avatar must not be stored in local account path: %v", err)
 	}
 }
 

--- a/internal/paon/api/s3_storage.go
+++ b/internal/paon/api/s3_storage.go
@@ -199,11 +199,42 @@ func (s *Server) deletePaperclipObject(ctx context.Context, key string) {
 }
 
 func accountImageObjectKey(accountID int64, kind string, style string, filename string) string {
+	return accountImageObjectKeyWithCachePrefix(accountID, kind, style, filename, false)
+}
+
+func accountImageObjectKeyForAccount(account models.Account, kind string, style string, filename string) string {
+	return accountImageObjectKeyWithCachePrefix(account.ID, kind, style, filename, accountImageUsesCachePrefix(account, kind))
+}
+
+func accountImageObjectKeyWithCachePrefix(accountID int64, kind string, style string, filename string, cachePrefix bool) string {
 	dir := "avatars"
 	if kind == "header" {
 		dir = "headers"
 	}
-	return path.Join("accounts", dir, strings.ReplaceAll(mediaPaperclipIDPartition(accountID), string(os.PathSeparator), "/"), style, filename)
+	parts := []string{"accounts", dir, strings.ReplaceAll(mediaPaperclipIDPartition(accountID), string(os.PathSeparator), "/"), style, filename}
+	if cachePrefix {
+		parts = append([]string{"cache"}, parts...)
+	}
+	return path.Join(parts...)
+}
+
+func accountImageUsesCachePrefix(account models.Account, kind string) bool {
+	if kind == "header" {
+		return account.HeaderUsesCachePrefix()
+	}
+	return account.AvatarUsesCachePrefix()
+}
+
+func accountImageAssetPath(account models.Account, kind string, style string, filename string) string {
+	dir := "avatars"
+	if kind == "header" {
+		dir = "headers"
+	}
+	prefix := ""
+	if accountImageUsesCachePrefix(account, kind) {
+		prefix = "cache/"
+	}
+	return prefix + "accounts/" + dir + "/" + strings.ReplaceAll(mediaPaperclipIDPartition(account.ID), string(os.PathSeparator), "/") + "/" + style + "/" + url.PathEscape(filename)
 }
 
 func customEmojiObjectKey(emoji models.CustomEmoji, style string, filename string) string {

--- a/internal/paon/api/s3_storage_test.go
+++ b/internal/paon/api/s3_storage_test.go
@@ -170,6 +170,18 @@ func TestAccountImageObjectKeyUsesRailsPaperclipIDPartition(t *testing.T) {
 	if got := accountImageObjectKey(42, "header", "static", "header.png"); got != "accounts/headers/000/000/042/static/header.png" {
 		t.Fatalf("header key = %q", got)
 	}
+	remote := models.Account{
+		ID:                         42,
+		Domain:                     sql.NullString{String: "remote.example", Valid: true},
+		AvatarStorageSchemaVersion: sql.NullInt64{Int64: 1, Valid: true},
+		HeaderStorageSchemaVersion: sql.NullInt64{Int64: 1, Valid: true},
+	}
+	if got := accountImageObjectKeyForAccount(remote, "avatar", "original", "avatar.png"); got != "cache/accounts/avatars/000/000/042/original/avatar.png" {
+		t.Fatalf("remote avatar key = %q", got)
+	}
+	if got := accountImageObjectKeyForAccount(remote, "header", "static", "header.png"); got != "cache/accounts/headers/000/000/042/static/header.png" {
+		t.Fatalf("remote header key = %q", got)
+	}
 }
 
 func TestS3SDKDefaultsBlankRegionToUSEast1(t *testing.T) {

--- a/internal/paon/models/models.go
+++ b/internal/paon/models/models.go
@@ -251,6 +251,14 @@ func (Account) TableName() string { return "accounts" }
 
 func (a Account) Local() bool { return !a.Domain.Valid || a.Domain.String == "" }
 
+func (a Account) AvatarUsesCachePrefix() bool {
+	return !a.Local() && a.AvatarStorageSchemaVersion.Valid && a.AvatarStorageSchemaVersion.Int64 >= 1
+}
+
+func (a Account) HeaderUsesCachePrefix() bool {
+	return !a.Local() && a.HeaderStorageSchemaVersion.Valid && a.HeaderStorageSchemaVersion.Int64 >= 1
+}
+
 func (a Account) Acct() string {
 	if a.Local() {
 		return a.Username

--- a/internal/paon/serializer/rest.go
+++ b/internal/paon/serializer/rest.go
@@ -3471,7 +3471,11 @@ func accountAvatar(cfg config.Config, account models.Account, static bool) strin
 			style = "static"
 			filename = paperclipStaticFilename(filename)
 		}
-		return cfg.SystemAssetURL("accounts/avatars/" + paperclipIDPartition(account.ID) + "/" + style + "/" + url.PathEscape(filename))
+		prefix := ""
+		if account.AvatarUsesCachePrefix() {
+			prefix = "cache/"
+		}
+		return cfg.SystemAssetURL(prefix + "accounts/avatars/" + paperclipIDPartition(account.ID) + "/" + style + "/" + url.PathEscape(filename))
 	}
 	return cfg.BaseURL() + "/avatars/original/missing.png"
 }
@@ -3490,7 +3494,11 @@ func accountHeader(cfg config.Config, account models.Account, static bool) strin
 			style = "static"
 			filename = paperclipStaticFilename(filename)
 		}
-		return cfg.SystemAssetURL("accounts/headers/" + paperclipIDPartition(account.ID) + "/" + style + "/" + url.PathEscape(filename))
+		prefix := ""
+		if account.HeaderUsesCachePrefix() {
+			prefix = "cache/"
+		}
+		return cfg.SystemAssetURL(prefix + "accounts/headers/" + paperclipIDPartition(account.ID) + "/" + style + "/" + url.PathEscape(filename))
 	}
 	return cfg.BaseURL() + "/headers/original/missing.png"
 }

--- a/internal/paon/serializer/rest_test.go
+++ b/internal/paon/serializer/rest_test.go
@@ -358,42 +358,45 @@ func TestAccountFromModelKeepsSuspendedGroupFlagLikeRails(t *testing.T) {
 
 func TestAccountFromModelRemoteAvatarHonorsCacheSettingAndStaticStyle(t *testing.T) {
 	account := models.Account{
-		ID:                42,
-		Username:          "alice",
-		CreatedAt:         time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC),
-		AvatarRemoteURL:   sql.NullString{String: "https://remote.example/avatar.gif", Valid: true},
-		HeaderRemoteURL:   "https://remote.example/header.gif",
-		AvatarFileName:    sql.NullString{String: "avatar.gif", Valid: true},
-		AvatarContentType: sql.NullString{String: "image/gif", Valid: true},
-		HeaderFileName:    sql.NullString{String: "header.gif", Valid: true},
-		HeaderContentType: sql.NullString{String: "image/gif", Valid: true},
+		ID:                         42,
+		Username:                   "alice",
+		Domain:                     sql.NullString{String: "remote.example", Valid: true},
+		CreatedAt:                  time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC),
+		AvatarRemoteURL:            sql.NullString{String: "https://remote.example/avatar.gif", Valid: true},
+		HeaderRemoteURL:            "https://remote.example/header.gif",
+		AvatarFileName:             sql.NullString{String: "avatar.gif", Valid: true},
+		AvatarContentType:          sql.NullString{String: "image/gif", Valid: true},
+		AvatarStorageSchemaVersion: sql.NullInt64{Int64: 1, Valid: true},
+		HeaderFileName:             sql.NullString{String: "header.gif", Valid: true},
+		HeaderContentType:          sql.NullString{String: "image/gif", Valid: true},
+		HeaderStorageSchemaVersion: sql.NullInt64{Int64: 1, Valid: true},
 	}
 
 	cached := AccountFromModel(config.Config{LocalDomain: "example.test", WebDomain: "example.test", Scheme: "https"}, account)
-	if cached.Avatar != "https://example.test/system/accounts/avatars/000/000/042/original/avatar.gif" {
+	if cached.Avatar != "https://example.test/system/cache/accounts/avatars/000/000/042/original/avatar.gif" {
 		t.Fatalf("cached avatar = %q", cached.Avatar)
 	}
-	if cached.AvatarStatic != "https://example.test/system/accounts/avatars/000/000/042/static/avatar.png" {
+	if cached.AvatarStatic != "https://example.test/system/cache/accounts/avatars/000/000/042/static/avatar.png" {
 		t.Fatalf("cached avatar_static = %q", cached.AvatarStatic)
 	}
-	if cached.Header != "https://example.test/system/accounts/headers/000/000/042/original/header.gif" {
+	if cached.Header != "https://example.test/system/cache/accounts/headers/000/000/042/original/header.gif" {
 		t.Fatalf("cached header = %q", cached.Header)
 	}
-	if cached.HeaderStatic != "https://example.test/system/accounts/headers/000/000/042/static/header.png" {
+	if cached.HeaderStatic != "https://example.test/system/cache/accounts/headers/000/000/042/static/header.png" {
 		t.Fatalf("cached header_static = %q", cached.HeaderStatic)
 	}
 
 	stored := AccountFromModel(config.Config{LocalDomain: "example.test", WebDomain: "example.test", Scheme: "https", StorageHost: "https://media.example.test/"}, account)
-	if stored.Avatar != "https://media.example.test/accounts/avatars/000/000/042/original/avatar.gif" {
+	if stored.Avatar != "https://media.example.test/cache/accounts/avatars/000/000/042/original/avatar.gif" {
 		t.Fatalf("storage-host avatar = %q", stored.Avatar)
 	}
-	if stored.AvatarStatic != "https://media.example.test/accounts/avatars/000/000/042/static/avatar.png" {
+	if stored.AvatarStatic != "https://media.example.test/cache/accounts/avatars/000/000/042/static/avatar.png" {
 		t.Fatalf("storage-host avatar_static = %q", stored.AvatarStatic)
 	}
-	if stored.Header != "https://media.example.test/accounts/headers/000/000/042/original/header.gif" {
+	if stored.Header != "https://media.example.test/cache/accounts/headers/000/000/042/original/header.gif" {
 		t.Fatalf("storage-host header = %q", stored.Header)
 	}
-	if stored.HeaderStatic != "https://media.example.test/accounts/headers/000/000/042/static/header.png" {
+	if stored.HeaderStatic != "https://media.example.test/cache/accounts/headers/000/000/042/static/header.png" {
 		t.Fatalf("storage-host header_static = %q", stored.HeaderStatic)
 	}
 


### PR DESCRIPTION
Rails Paperclip stores cached remote account avatars and headers under cache/accounts/... and cache/headers/...; align Paon by routing the new AvatarUsesCachePrefix()/HeaderUsesCachePrefix() helpers through S3 object keys, cache busting, local storage, backups, REST serialization, embeds, and cleanup.