### PR TITLE
staging

### DIFF
--- a/internal/paon/api/activitypub_delivery.go
+++ b/internal/paon/api/activitypub_delivery.go
@@ -1555,9 +1555,9 @@ func activityPubBlockURIForSerializer(s *Server, local models.Account, blockID i
 }
 
 func (s *Server) deliverActivityPubFollowResponse(kind string, local models.Account, remote models.Account, followID int64, followURI string) error {
-	inboxURL := remote.InboxURL
+	inboxURL := activityPubPreferredInboxURL(remote.SharedInboxURL, remote.InboxURL)
 	if strings.TrimSpace(inboxURL) == "" {
-		return nil
+		return fmt.Errorf("activitypub %s Follow response target account_id=%d has no inbox", kind, remote.ID)
 	}
 	body, err := json.Marshal(activityPubFollowResponsePayload(s, kind, local, remote, followID, followURI))
 	if err != nil {

--- a/internal/paon/api/activitypub_follow_response_integration_test.go
+++ b/internal/paon/api/activitypub_follow_response_integration_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package api
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mstdn-plusminus-io/paon/internal/paon/config"
+	paondb "github.com/mstdn-plusminus-io/paon/internal/paon/db"
+	"github.com/mstdn-plusminus-io/paon/internal/paon/migrate"
+	"github.com/mstdn-plusminus-io/paon/internal/paon/models"
+	"gorm.io/gorm"
+)
+
+func TestAcceptFollowUsesPersonalInboxRecipientWithoutHostSpecificLogic(t *testing.T) {
+	databaseURL := os.Getenv("PAON_TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Fatal("PAON_TEST_DATABASE_URL is required for integration tests")
+	}
+	cfg := config.Config{
+		DatabaseURL:          databaseURL,
+		DatabaseMaxOpenConns: 5,
+		DatabaseMaxIdleConns: 2,
+		LocalDomain:          "paon.example",
+		WebDomain:            "paon.example",
+		SecretKeyBase:        "integration-secret",
+	}
+	database, err := paondb.Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Exec(`DROP SCHEMA public CASCADE; CREATE SCHEMA public`).Error; err != nil {
+		t.Fatal(err)
+	}
+	if applied, err := migrate.Run(context.Background(), database); err != nil || !applied {
+		t.Fatalf("migrate = %v, %v", applied, err)
+	}
+
+	now := time.Now().UTC()
+	local := models.Account{Username: "alice", CreatedAt: now, UpdatedAt: now}
+	if err := database.Create(&local).Error; err != nil {
+		t.Fatal(err)
+	}
+	remote := models.Account{
+		Username:  "bob",
+		Domain:    sql.NullString{String: "remote.example", Valid: true},
+		URI:       "https://remote.example/users/bob",
+		Protocol:  1,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := database.Create(&remote).Error; err != nil {
+		t.Fatal(err)
+	}
+	request := models.FollowRequest{
+		AccountID:       local.ID,
+		TargetAccountID: remote.ID,
+		ShowReblogs:     true,
+		URI:             models.NullSafeString("https://paon.example/payloads/original-follow"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := database.Create(&request).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte(`{
+		"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/security/v1"],
+		"id":"https://remote.example/activities/accept-follow",
+		"type":"Accept",
+		"actor":"https://remote.example/users/bob",
+		"object":{
+			"id":"https://remote.example/follows/rewritten-id",
+			"type":"Follow",
+			"object":"https://remote.example/users/bob"
+		}
+	}`)
+	server := &Server{cfg: cfg, db: database}
+	if err := server.processActivityPubInboxForDeliveredToWithContext(context.Background(), body, &remote, nil, local.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	var follow models.Follow
+	if err := database.Where("account_id = ? AND target_account_id = ?", local.ID, remote.ID).First(&follow).Error; err != nil {
+		t.Fatalf("accepted follow was not created: %v", err)
+	}
+	if string(follow.URI) != string(request.URI) {
+		t.Fatalf("follow URI = %q, want %q", follow.URI, request.URI)
+	}
+	if err := database.Where("id = ?", request.ID).First(&models.FollowRequest{}).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("follow request still exists or lookup failed: %v", err)
+	}
+
+	if err := server.processActivityPubInboxForDeliveredToWithContext(context.Background(), body, &remote, nil, local.ID); err != nil {
+		t.Fatalf("duplicate Accept should be idempotent: %v", err)
+	}
+
+	if err := database.Where("account_id = ? AND target_account_id = ?", local.ID, remote.ID).Delete(&models.Follow{}).Error; err != nil {
+		t.Fatal(err)
+	}
+	err = server.processActivityPubInboxForDeliveredToWithContext(context.Background(), body, &remote, nil, local.ID)
+	if !errors.Is(err, errActivityPubEventNotApplied) {
+		t.Fatalf("unmatched Accept error = %v, want errActivityPubEventNotApplied", err)
+	}
+
+	sharedInboxRequest := models.FollowRequest{
+		AccountID:       local.ID,
+		TargetAccountID: remote.ID,
+		ShowReblogs:     true,
+		URI:             models.NullSafeString("https://paon.example/payloads/shared-inbox-follow"),
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := database.Create(&sharedInboxRequest).Error; err != nil {
+		t.Fatal(err)
+	}
+	sharedInboxBody := []byte(`{
+		"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/security/v1"],
+		"id":"https://remote.example/activities/shared-inbox-accept",
+		"type":"Accept",
+		"actor":"https://remote.example/users/bob",
+		"object":{
+			"id":"https://remote.example/follows/another-rewritten-id",
+			"type":"Follow",
+			"object":"https://remote.example/users/bob"
+		}
+	}`)
+	if err := server.processActivityPubInboxForDeliveredToWithContext(context.Background(), sharedInboxBody, &remote, nil, 0); err != nil {
+		t.Fatalf("shared-inbox Accept with one pending request: %v", err)
+	}
+	if err := database.Where("id = ?", sharedInboxRequest.ID).First(&models.FollowRequest{}).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("shared-inbox follow request still exists or lookup failed: %v", err)
+	}
+
+	for _, username := range []string{"carol", "dave"} {
+		account := models.Account{Username: username, CreatedAt: now, UpdatedAt: now}
+		if err := database.Create(&account).Error; err != nil {
+			t.Fatal(err)
+		}
+		request := models.FollowRequest{
+			AccountID:       account.ID,
+			TargetAccountID: remote.ID,
+			ShowReblogs:     true,
+			URI:             models.NullSafeString("https://paon.example/payloads/" + username + "-follow"),
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		if err := database.Create(&request).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	err = server.processActivityPubInboxForDeliveredToWithContext(context.Background(), sharedInboxBody, &remote, nil, 0)
+	if !errors.Is(err, errActivityPubEventNotApplied) || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("ambiguous shared-inbox Accept error = %v", err)
+	}
+}

--- a/internal/paon/api/activitypub_inbox.go
+++ b/internal/paon/api/activitypub_inbox.go
@@ -23,7 +23,14 @@ import (
 
 const activityPubPublicIRI = "https://www.w3.org/ns/activitystreams#Public"
 
-var errActivityPubPollVoteAlreadyVoted = errors.New("activitypub poll vote already voted")
+var (
+	errActivityPubPollVoteAlreadyVoted = errors.New("activitypub poll vote already voted")
+	errActivityPubEventNotApplied      = errors.New("activitypub event was not applied")
+)
+
+func activityPubEventNotAppliedf(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", errActivityPubEventNotApplied, fmt.Sprintf(format, args...))
+}
 
 type activityPubProcessingOptions struct {
 	OverrideTimestamps   bool
@@ -49,42 +56,40 @@ func (s *Server) processActivityPubInboxForDeliveredTo(body []byte, actor *model
 
 func (s *Server) processActivityPubInboxForDeliveredToWithContext(ctx context.Context, body []byte, actor *models.Account, target *models.Account, deliveredToAccountID int64) error {
 	body = activityPubProcessCollectionBody(body)
-	actorID := int64(0)
-	if actor != nil {
-		actorID = actor.ID
-	}
 	if !json.Valid(body) {
-		logActivityPubProcessingIssue("ignored", "invalid_json", body, actorID, deliveredToAccountID, errors.New("invalid JSON document"))
-		return nil
+		return activityPubEventNotAppliedf("invalid JSON document")
 	}
 	if !activityPayloadSupportedContext(body) {
-		logActivityPubProcessingIssue("ignored", "unsupported_jsonld_context", body, actorID, deliveredToAccountID, errors.New("unsupported JSON-LD context"))
-		return nil
+		return activityPubEventNotAppliedf("unsupported JSON-LD context")
 	}
 	payload, err := parseActivityPayload(body)
 	if err != nil {
-		logActivityPubProcessingIssue("ignored", "payload_parse_failed", body, actorID, deliveredToAccountID, err)
-		return nil
+		return activityPubEventNotAppliedf("parse payload: %v", err)
 	}
 	if actor == nil {
-		logActivityPubProcessingIssue("ignored", "verified_actor_missing", body, 0, deliveredToAccountID, errors.New("verified actor is missing"))
-		return nil
+		return activityPubEventNotAppliedf("verified actor is missing")
 	}
-	if s.db == nil || actor.Local() {
-		return nil
+	if s == nil || s.db == nil {
+		return activityPubEventNotAppliedf("database is unavailable")
+	}
+	target, err = s.activityPubDeliveredToAccount(target, deliveredToAccountID)
+	if err != nil {
+		return err
+	}
+	if actor.Local() {
+		return activityPubEventNotAppliedf("verified actor %d is local", actor.ID)
 	}
 	var relayedThrough *models.Account
 	if activityPayloadDifferentActor(payload, actor) {
 		verifiedActor := s.activityPubLinkedDataSignatureActor(body, payload)
 		if verifiedActor == nil {
-			logActivityPubUnsupportedPayload(payload, actor.ID, "actor_mismatch_without_linked_data_signature")
-			return nil
+			return activityPubEventNotAppliedf("activity actor does not match verified HTTP signature actor")
 		}
 		relayedThrough = actor
 		actor = verifiedActor
 	}
 	if actor.Local() {
-		return nil
+		return activityPubEventNotAppliedf("linked-data signature actor %d is local", actor.ID)
 	}
 	if actor.SuspendedAt.Valid && !activityPubActivityAllowedWhileSuspended(payload.Type) {
 		return nil
@@ -98,6 +103,31 @@ func (s *Server) processActivityPubInboxForDeliveredToWithContext(ctx context.Co
 		return s.processActivityPubCollectionWithContext(ctx, payload, actor, target, relayedThrough, options)
 	}
 	return s.processActivityPubPayloadWithContext(ctx, payload, actor, target, relayedThrough, options)
+}
+
+func (s *Server) activityPubDeliveredToAccount(target *models.Account, deliveredToAccountID int64) (*models.Account, error) {
+	if deliveredToAccountID == 0 {
+		return target, nil
+	}
+	if target != nil {
+		if target.ID != deliveredToAccountID || !target.Local() {
+			return nil, activityPubEventNotAppliedf(
+				"personal inbox account_id=%d conflicts with processing target account_id=%d",
+				deliveredToAccountID,
+				target.ID,
+			)
+		}
+		return target, nil
+	}
+	var deliveredTo models.Account
+	err := s.db.Where("id = ? AND domain IS NULL", deliveredToAccountID).First(&deliveredTo).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, activityPubEventNotAppliedf("personal inbox account %d is not a local account", deliveredToAccountID)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load personal inbox account %d: %w", deliveredToAccountID, err)
+	}
+	return &deliveredTo, nil
 }
 
 func activityPubProcessCollectionBody(body []byte) []byte {
@@ -271,7 +301,7 @@ func activityPayloadWithoutActor(payload activityPayload) activityPayload {
 }
 
 func activityPayloadActorValueOrID(payload activityPayload) string {
-	return payload.ActorRaw
+	return firstNonEmpty(payload.Actor, payload.ActorRaw)
 }
 
 func activityPayloadDifferentActor(payload activityPayload, actor *models.Account) bool {
@@ -340,7 +370,7 @@ func (s *Server) processActivityPubPayload(payload activityPayload, actor *model
 
 func (s *Server) processActivityPubPayloadWithContext(ctx context.Context, payload activityPayload, actor *models.Account, target *models.Account, relayedThrough *models.Account, options activityPubProcessingOptions) error {
 	if activityPayloadDifferentActor(payload, actor) {
-		return nil
+		return activityPubEventNotAppliedf("activity actor does not match processing actor")
 	}
 	switch payload.Type {
 	case "Create":
@@ -362,9 +392,9 @@ func (s *Server) processActivityPubPayloadWithContext(ctx context.Context, paylo
 	case "Move":
 		return s.processActivityPubMove(payload, actor)
 	case "Accept":
-		return s.processActivityPubAccept(payload, actor)
+		return s.processActivityPubAccept(payload, actor, options.DeliveredToAccountID)
 	case "Reject":
-		return s.processActivityPubReject(payload, actor)
+		return s.processActivityPubReject(payload, actor, options.DeliveredToAccountID)
 	case "Block":
 		return s.processActivityPubBlock(payload, actor)
 	case "Flag":
@@ -400,16 +430,16 @@ func (s *Server) processActivityPubPayloadWithContext(ctx context.Context, paylo
 		}
 	}
 	logActivityPubUnsupportedPayload(payload, actor.ID, "unsupported_activity_or_object_type")
-	return nil
+	return activityPubEventNotAppliedf("unsupported activity type %q or object type %q", payload.Type, payload.Object.TypeExact)
 }
 
 func (s *Server) processActivityPubDereferencedCreate(payload activityPayload, actor *models.Account, target *models.Account, relayedThrough *models.Account, options activityPubProcessingOptions) error {
 	objectFetchURI, objectURI := activityPubDereferenceFetchURI(payload.Object.ID)
 	if s == nil || actor == nil || objectFetchURI == "" || objectURI == "" {
-		return nil
+		return activityPubEventNotAppliedf("dereferenced Create has no fetchable object")
 	}
 	if activityPubURIHostMismatch(actor.URI, objectURI) {
-		return nil
+		return activityPubEventNotAppliedf("dereferenced Create object host does not match actor")
 	}
 	if disallowed, err := s.remoteActivityDomainNotAllowed(objectURI); err != nil || disallowed {
 		return err
@@ -430,16 +460,16 @@ func (s *Server) processActivityPubDereferencedCreate(payload activityPayload, a
 		return err
 	}
 	if dereferenced.Type != "Create" || !activityObjectIsStatus(dereferenced.Object) {
-		return nil
+		return activityPubEventNotAppliedf("dereferenced Create did not resolve to a status")
 	}
 	if dereferenced.Actor != "" && actor.URI != "" && dereferenced.Actor != actor.URI {
-		return nil
+		return activityPubEventNotAppliedf("dereferenced Create actor does not match verified actor")
 	}
 	if dereferenced.Object.AttributedTo == "" {
 		dereferenced.Object.AttributedTo = actor.URI
 	}
 	if !activityNoteBelongsToActor(dereferenced.Object, actor) {
-		return nil
+		return activityPubEventNotAppliedf("dereferenced Create object does not belong to verified actor")
 	}
 	dereferenced.ID = firstNonEmpty(payload.ID, dereferenced.ID)
 	dereferenced.Actor = firstNonEmpty(payload.Actor, dereferenced.Actor, actor.URI)
@@ -460,7 +490,7 @@ func firstNonEmptyStringSlice(values ...[]string) []string {
 
 func (s *Server) processActivityPubUndoReference(object activityObject, actor *models.Account) error {
 	if object.ID == "" && !object.Reference && !object.IDPresent {
-		return nil
+		return activityPubEventNotAppliedf("Undo object reference is missing")
 	}
 	if handled, err := s.processActivityPubUndoAnnounceWithTombstone(object, actor, false); err != nil || handled {
 		return err
@@ -492,7 +522,7 @@ func activityPubActorRefreshStale(actor *models.Account, now time.Time) bool {
 
 func (s *Server) processActivityPubAdd(payload activityPayload, actor *models.Account, options activityPubProcessingOptions) error {
 	if actor == nil || actor.ID == 0 || !activityTargetIsFeaturedCollection(payload.Target, s, *actor) {
-		return nil
+		return activityPubEventNotAppliedf("Add target is not the verified actor's featured collection")
 	}
 	if payload.Object.TypeExact == "Hashtag" {
 		_, _, err := s.createFeaturedTagForAccount(actor, payload.Object.Name, true)
@@ -527,10 +557,13 @@ func (s *Server) processActivityPubAdd(payload activityPayload, actor *models.Ac
 		}
 	}
 	if err != nil || status == nil {
-		return err
+		if err != nil {
+			return err
+		}
+		return activityPubEventNotAppliedf("Add object status %q could not be resolved", payload.Object.ID)
 	}
 	if !activityPubStatusPinValidForRails(*actor, *status) {
-		return nil
+		return activityPubEventNotAppliedf("Add object status %q cannot be pinned by actor", payload.Object.ID)
 	}
 	now := time.Now().UTC()
 	return s.db.Clauses(clause.OnConflict{DoNothing: true}).Create(&models.StatusPin{AccountID: actor.ID, StatusID: status.ID, CreatedAt: now, UpdatedAt: now}).Error
@@ -542,12 +575,12 @@ func activityPubStatusPinValidForRails(actor models.Account, status models.Statu
 
 func (s *Server) processActivityPubRemove(payload activityPayload, actor *models.Account) error {
 	if actor == nil || actor.ID == 0 || !activityTargetIsFeaturedCollection(payload.Target, s, *actor) {
-		return nil
+		return activityPubEventNotAppliedf("Remove target is not the verified actor's featured collection")
 	}
 	if payload.Object.TypeExact == "Hashtag" {
 		normalized, _, ok := normalizeTagName(payload.Object.Name)
 		if !ok {
-			return nil
+			return activityPubEventNotAppliedf("Remove Hashtag name is invalid")
 		}
 		return s.db.Exec(`
 			DELETE FROM featured_tags
@@ -558,8 +591,15 @@ func (s *Server) processActivityPubRemove(payload activityPayload, actor *models
 		`, actor.ID, normalized).Error
 	}
 	status, err := s.statusFromActivityURI(payload.Object.ID)
-	if err != nil || status == nil || status.AccountID != actor.ID {
+	if err != nil {
 		return err
+	}
+	if status == nil {
+		// The requested final state is already reached when the status is gone.
+		return nil
+	}
+	if status.AccountID != actor.ID {
+		return activityPubEventNotAppliedf("Remove object status %q does not belong to actor", payload.Object.ID)
 	}
 	var pin models.StatusPin
 	deleted := false
@@ -594,7 +634,7 @@ func activityTargetIsFeaturedCollection(target string, s *Server, actor models.A
 
 func (s *Server) processActivityPubFlag(payload activityPayload, actor *models.Account) error {
 	if actor == nil || actor.ID == 0 || actor.Local() {
-		return nil
+		return activityPubEventNotAppliedf("Flag actor must be a persisted remote account")
 	}
 	reject, err := s.activityPubRejectsReportsFromDomain(*actor)
 	if err != nil || reject {
@@ -605,15 +645,18 @@ func (s *Server) processActivityPubFlag(payload activityPayload, actor *models.A
 		uris = []string{payload.Object.ID}
 	}
 	if len(uris) == 0 {
-		return nil
+		return activityPubEventNotAppliedf("Flag has no reportable objects")
 	}
 	statusesByAccount, err := s.activityPubFlagStatusesByAccount(uris)
 	if err != nil {
 		return err
 	}
 	targetAccounts, err := s.activityPubFlagTargetAccounts(uris)
-	if err != nil || len(targetAccounts) == 0 {
+	if err != nil {
 		return err
+	}
+	if len(targetAccounts) == 0 {
+		return activityPubEventNotAppliedf("Flag did not identify a known target account")
 	}
 	comment := activityPubFlagComment(payload.Content)
 	for _, target := range targetAccounts {
@@ -870,17 +913,28 @@ func (s *Server) activityPubFlagReportStatusIDs(source models.Account, target mo
 	return out, nil
 }
 
-func (s *Server) processActivityPubAccept(payload activityPayload, actor *models.Account) error {
+func (s *Server) processActivityPubAccept(payload activityPayload, actor *models.Account, deliveredToAccountID int64) error {
 	if actor == nil || actor.ID == 0 || actor.Local() {
-		return nil
+		return activityPubEventNotAppliedf("Accept actor must be a persisted remote account")
 	}
 	if handled, err := s.processActivityPubRelayFollowResponse(payload.Object.ID, payload.Object.IDPresent, relayStateAccepted); handled || err != nil {
 		return err
 	}
-	request, err := s.outgoingFollowRequestFromActivity(payload.Object, actor)
-	if err != nil || request == nil {
+	match, err := s.outgoingFollowResponseFromActivity(payload.Object, actor, deliveredToAccountID)
+	if err != nil {
 		return err
 	}
+	if match.Request == nil {
+		if match.Follow != nil {
+			return nil
+		}
+		return activityPubEventNotAppliedf(
+			"Accept did not match an outgoing Follow request source_account_id=%d target_account_id=%d",
+			match.SourceAccountID,
+			actor.ID,
+		)
+	}
+	request := match.Request
 	hasLocalFollower, err := s.remoteAccountHasLocalFollowers(actor.ID)
 	if err != nil {
 		return err
@@ -905,39 +959,39 @@ func (s *Server) processActivityPubAccept(payload activityPayload, actor *models
 	return nil
 }
 
-func (s *Server) processActivityPubReject(payload activityPayload, actor *models.Account) error {
+func (s *Server) processActivityPubReject(payload activityPayload, actor *models.Account, deliveredToAccountID int64) error {
 	if actor == nil || actor.ID == 0 || actor.Local() {
-		return nil
+		return activityPubEventNotAppliedf("Reject actor must be a persisted remote account")
 	}
 	if handled, err := s.processActivityPubRelayFollowResponse(payload.Object.ID, payload.Object.IDPresent, relayStateRejected); handled || err != nil {
 		return err
 	}
-	request, err := s.outgoingFollowRequestFromActivity(payload.Object, actor)
+	match, err := s.outgoingFollowResponseFromActivity(payload.Object, actor, deliveredToAccountID)
 	if err != nil {
 		return err
 	}
-	if request != nil {
-		affectedListIDs, err := s.deleteOutgoingFollowRequest(*request)
+	if match.Request != nil {
+		affectedListIDs, err := s.deleteOutgoingFollowRequest(*match.Request)
 		if err != nil {
 			return err
 		}
 		for _, listID := range uniqueInt64s(affectedListIDs) {
 			_ = s.clearListFeedCacheContext(context.Background(), listID)
 		}
-		s.invalidateRelationshipCaches(context.Background(), request.AccountID, actor.ID)
+		s.invalidateRelationshipCaches(context.Background(), match.Request.AccountID, actor.ID)
 		return nil
 	}
-	follow, err := s.outgoingFollowFromActivity(payload.Object, actor)
-	if err != nil || follow == nil {
-		return err
+	if match.Follow == nil {
+		// A repeated Reject is already in its requested final state.
+		return nil
 	}
 	if err := s.db.Transaction(func(tx *gorm.DB) error {
-		return deleteFollow(tx, *follow)
+		return deleteFollow(tx, *match.Follow)
 	}); err != nil {
 		return err
 	}
-	s.unmergeAfterUnfollowBestEffort(context.Background(), actor.ID, follow.Account)
-	s.invalidateFollowRelationshipCaches(context.Background(), follow.Account, actor.ID)
+	s.unmergeAfterUnfollowBestEffort(context.Background(), actor.ID, match.Follow.Account)
+	s.invalidateFollowRelationshipCaches(context.Background(), match.Follow.Account, actor.ID)
 	s.meiliReindexPrivateStatusesForAccountsBestEffort(context.Background(), actor.ID)
 	return nil
 }
@@ -995,14 +1049,17 @@ func (s *Server) refreshActivityPubRemoteAccount(ctx context.Context, account *m
 
 func (s *Server) processActivityPubBlock(payload activityPayload, actor *models.Account) error {
 	if actor == nil || actor.ID == 0 || actor.Local() {
-		return nil
+		return activityPubEventNotAppliedf("Block actor must be a persisted remote account")
 	}
 	activityID := activityPayloadIDValueOrID(payload)
 	activityIDPresent := strings.TrimSpace(activityID) != ""
 	generateBlockURI := !payload.IDPresent
 	target, err := s.localAccountFromActivityURI(payload.Object.ID)
-	if err != nil || target == nil || !target.Local() || target.ID == actor.ID {
+	if err != nil {
 		return err
+	}
+	if target == nil || !target.Local() || target.ID == actor.ID {
+		return activityPubEventNotAppliedf("Block target %q is not a distinct local account", payload.Object.ID)
 	}
 	now := time.Now().UTC()
 	var changed bool
@@ -1160,45 +1217,203 @@ func (s *Server) blockTargetFromURI(uri string, accountID int64) (*models.Accoun
 	return &target, nil
 }
 
-func (s *Server) outgoingFollowRequestFromActivity(object activityObject, target *models.Account) (*models.FollowRequest, error) {
+type outgoingFollowResponseMatch struct {
+	Request         *models.FollowRequest
+	Follow          *models.Follow
+	SourceAccountID int64
+}
+
+func (s *Server) outgoingFollowResponseFromActivity(object activityObject, target *models.Account, deliveredToAccountID int64) (outgoingFollowResponseMatch, error) {
+	var match outgoingFollowResponseMatch
 	if s == nil || s.db == nil || target == nil || target.ID == 0 {
-		return nil, nil
+		return match, activityPubEventNotAppliedf("Follow response target is unavailable")
 	}
-	query := s.db.Preload("Account").Where("target_account_id = ?", target.ID)
-	if object.ID != "" {
-		query = query.Where("uri = ?", object.ID)
-	} else if activityPubEmbeddedFollowActorURI(object) != "" {
-		source, err := s.localAccountFromActivityURI(activityPubEmbeddedFollowActorURI(object))
-		if err != nil || source == nil || !source.Local() {
-			return nil, err
+	if object.TypePresent && object.TypeExact != "Follow" {
+		return match, activityPubEventNotAppliedf("Follow response object type is %q", object.TypeExact)
+	}
+	if object.TypeExact == "Follow" && object.ObjectIDPresent && firstNonEmpty(object.ObjectID, activityURIFromBearcapRaw(object.ObjectIDRaw)) != target.URI {
+		return match, activityPubEventNotAppliedf(
+			"embedded Follow target %q does not match response actor %q",
+			firstNonEmpty(object.ObjectID, object.ObjectIDRaw),
+			target.URI,
+		)
+	}
+
+	embeddedSourceAccountID := int64(0)
+	if sourceURI := activityPubEmbeddedFollowActorURI(object); sourceURI != "" {
+		source, err := s.localAccountFromActivityURI(sourceURI)
+		if err != nil {
+			return match, fmt.Errorf("resolve embedded Follow actor %q: %w", sourceURI, err)
 		}
-		query = query.Where("account_id = ?", source.ID)
-	} else {
-		return nil, nil
+		if source == nil || !source.Local() {
+			return match, activityPubEventNotAppliedf("embedded Follow actor %q is not a local account", sourceURI)
+		}
+		embeddedSourceAccountID = source.ID
 	}
+
+	deliveredSourceAccountID := int64(0)
+	if deliveredToAccountID != 0 {
+		var deliveredTo models.Account
+		err := s.db.Select("id", "domain").
+			Where("id = ? AND domain IS NULL", deliveredToAccountID).
+			First(&deliveredTo).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return match, activityPubEventNotAppliedf("personal inbox account %d is not a local account", deliveredToAccountID)
+		}
+		if err != nil {
+			return match, fmt.Errorf("load personal inbox account %d: %w", deliveredToAccountID, err)
+		}
+		deliveredSourceAccountID = deliveredTo.ID
+	}
+	if embeddedSourceAccountID != 0 && deliveredSourceAccountID != 0 && embeddedSourceAccountID != deliveredSourceAccountID {
+		return match, activityPubEventNotAppliedf(
+			"embedded Follow actor account_id=%d conflicts with personal inbox account_id=%d",
+			embeddedSourceAccountID,
+			deliveredSourceAccountID,
+		)
+	}
+	match.SourceAccountID = firstNonZeroInt64(embeddedSourceAccountID, deliveredSourceAccountID)
+
+	if strings.TrimSpace(object.ID) != "" {
+		var request models.FollowRequest
+		err := s.db.Preload("Account").
+			Where("target_account_id = ? AND uri = ?", target.ID, object.ID).
+			First(&request).Error
+		if err == nil {
+			if match.SourceAccountID != 0 && match.SourceAccountID != request.AccountID {
+				return match, activityPubEventNotAppliedf(
+					"Follow request source account_id=%d conflicts with response source account_id=%d",
+					request.AccountID,
+					match.SourceAccountID,
+				)
+			}
+			match.Request = &request
+			match.SourceAccountID = request.AccountID
+			return match, nil
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return match, err
+		}
+
+		var follow models.Follow
+		err = s.db.Preload("Account").
+			Where("target_account_id = ? AND uri = ?", target.ID, object.ID).
+			First(&follow).Error
+		if err == nil {
+			if match.SourceAccountID != 0 && match.SourceAccountID != follow.AccountID {
+				return match, activityPubEventNotAppliedf(
+					"Follow source account_id=%d conflicts with response source account_id=%d",
+					follow.AccountID,
+					match.SourceAccountID,
+				)
+			}
+			match.Follow = &follow
+			match.SourceAccountID = follow.AccountID
+			return match, nil
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return match, err
+		}
+	}
+
+	if match.SourceAccountID == 0 {
+		request, follow, err := s.uniqueOutgoingFollowResponseCandidate(target.ID)
+		if err != nil {
+			return match, err
+		}
+		if request != nil {
+			match.Request = request
+			match.SourceAccountID = request.AccountID
+			return match, nil
+		}
+		if follow != nil {
+			match.Follow = follow
+			match.SourceAccountID = follow.AccountID
+			return match, nil
+		}
+		return match, activityPubEventNotAppliedf("Follow response has no resolvable local source account")
+	}
+
 	var request models.FollowRequest
-	err := query.First(&request).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) && object.ID != "" && object.Actor != "" {
-		source, sourceErr := s.localAccountFromActivityURI(activityPubEmbeddedFollowActorURI(object))
-		if sourceErr != nil || source == nil || !source.Local() {
-			return nil, sourceErr
-		}
-		err = s.db.Preload("Account").Where("target_account_id = ? AND account_id = ?", target.ID, source.ID).First(&request).Error
+	err := s.db.Preload("Account").
+		Where("target_account_id = ? AND account_id = ?", target.ID, match.SourceAccountID).
+		First(&request).Error
+	if err == nil {
+		match.Request = &request
+		return match, nil
 	}
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, nil
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return match, err
 	}
-	if err != nil {
-		return nil, err
+
+	var follow models.Follow
+	err = s.db.Preload("Account").
+		Where("target_account_id = ? AND account_id = ?", target.ID, match.SourceAccountID).
+		First(&follow).Error
+	if err == nil {
+		match.Follow = &follow
+		return match, nil
 	}
-	return &request, nil
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return match, err
+	}
+	return match, nil
+}
+
+func (s *Server) uniqueOutgoingFollowResponseCandidate(targetAccountID int64) (*models.FollowRequest, *models.Follow, error) {
+	var requests []models.FollowRequest
+	if err := s.db.Preload("Account").
+		Where("target_account_id = ?", targetAccountID).
+		Order("id ASC").
+		Limit(2).
+		Find(&requests).Error; err != nil {
+		return nil, nil, err
+	}
+	switch len(requests) {
+	case 1:
+		return &requests[0], nil, nil
+	case 2:
+		return nil, nil, activityPubEventNotAppliedf(
+			"Follow response is ambiguous for target_account_id=%d: multiple pending requests",
+			targetAccountID,
+		)
+	}
+
+	var follows []models.Follow
+	if err := s.db.Preload("Account").
+		Where("target_account_id = ?", targetAccountID).
+		Order("id ASC").
+		Limit(2).
+		Find(&follows).Error; err != nil {
+		return nil, nil, err
+	}
+	switch len(follows) {
+	case 1:
+		return nil, &follows[0], nil
+	case 2:
+		return nil, nil, activityPubEventNotAppliedf(
+			"Follow response is ambiguous for target_account_id=%d: multiple existing follows",
+			targetAccountID,
+		)
+	default:
+		return nil, nil, nil
+	}
 }
 
 func activityPubEmbeddedFollowActorURI(object activityObject) string {
 	if object.TypeExact != "Follow" {
 		return ""
 	}
-	return firstNonEmpty(object.ActorRaw, object.Actor)
+	return firstNonEmpty(object.Actor, activityURIFromBearcapRaw(object.ActorRaw))
+}
+
+func firstNonZeroInt64(values ...int64) int64 {
+	for _, value := range values {
+		if value != 0 {
+			return value
+		}
+	}
+	return 0
 }
 
 func (s *Server) acceptOutgoingFollowRequest(request models.FollowRequest) (*models.Follow, bool, []int64, error) {
@@ -1281,8 +1496,19 @@ func (s *Server) deleteOutgoingFollowRequest(request models.FollowRequest) ([]in
 
 func (s *Server) processActivityPubUndoAccept(object activityObject, actor *models.Account) error {
 	follow, err := s.outgoingFollowFromUndoAccept(object, actor)
-	if err != nil || follow == nil {
+	if err != nil {
 		return err
+	}
+	if follow == nil {
+		request, requestErr := s.outgoingFollowRequestFromUndoAccept(object, actor)
+		if requestErr != nil {
+			return requestErr
+		}
+		if request != nil {
+			// A repeated Undo Accept already restored the outgoing request.
+			return nil
+		}
+		return activityPubEventNotAppliedf("Undo Accept did not match an outgoing Follow")
 	}
 	if err := s.revokeOutgoingFollowToRequest(*follow); err != nil {
 		return err
@@ -1293,9 +1519,30 @@ func (s *Server) processActivityPubUndoAccept(object activityObject, actor *mode
 	return nil
 }
 
+func (s *Server) outgoingFollowRequestFromUndoAccept(object activityObject, target *models.Account) (*models.FollowRequest, error) {
+	if s == nil || s.db == nil || target == nil || target.ID == 0 {
+		return nil, activityPubEventNotAppliedf("Undo Accept target is unavailable")
+	}
+	query := s.db.Where("target_account_id = ?", target.ID)
+	if object.ObjectIDPresent {
+		query = query.Where("uri = ?", activityPubUndoTargetURI(object))
+	} else {
+		query = query.Where("uri IS NULL")
+	}
+	var request models.FollowRequest
+	err := query.First(&request).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &request, nil
+}
+
 func (s *Server) outgoingFollowFromUndoAccept(object activityObject, target *models.Account) (*models.Follow, error) {
 	if s == nil || s.db == nil || target == nil || target.ID == 0 {
-		return nil, nil
+		return nil, activityPubEventNotAppliedf("Undo Accept target is unavailable")
 	}
 	query := s.db.Preload("Account").Where("target_account_id = ?", target.ID)
 	if object.ObjectIDPresent {
@@ -1334,60 +1581,33 @@ func (s *Server) revokeOutgoingFollowToRequest(follow models.Follow) error {
 	})
 }
 
-func (s *Server) outgoingFollowFromActivity(object activityObject, target *models.Account) (*models.Follow, error) {
-	if s == nil || s.db == nil || target == nil || target.ID == 0 {
-		return nil, nil
-	}
-	query := s.db.Preload("Account").Where("target_account_id = ?", target.ID)
-	if object.ID != "" {
-		query = query.Where("uri = ?", object.ID)
-	} else if activityPubEmbeddedFollowActorURI(object) != "" {
-		source, err := s.localAccountFromActivityURI(activityPubEmbeddedFollowActorURI(object))
-		if err != nil || source == nil || !source.Local() {
-			return nil, err
-		}
-		query = query.Where("account_id = ?", source.ID)
-	} else {
-		return nil, nil
-	}
-	var follow models.Follow
-	err := query.First(&follow).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) && object.ID != "" && object.Actor != "" {
-		source, sourceErr := s.localAccountFromActivityURI(activityPubEmbeddedFollowActorURI(object))
-		if sourceErr != nil || source == nil || !source.Local() {
-			return nil, sourceErr
-		}
-		err = s.db.Preload("Account").Where("target_account_id = ? AND account_id = ?", target.ID, source.ID).First(&follow).Error
-	}
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &follow, nil
-}
-
 func (s *Server) processActivityPubMove(payload activityPayload, actor *models.Account) error {
 	if actor == nil || actor.ID == 0 || actor.Local() {
-		return nil
+		return activityPubEventNotAppliedf("Move actor must be a persisted remote account")
 	}
 	sourceURI := actor.URI
 	if payload.Object.ID != sourceURI || payload.Target == "" {
-		return nil
+		return activityPubEventNotAppliedf("Move source or target is invalid")
 	}
 	processing, err := s.markActivityPubMoveAsProcessing(context.Background(), actor.ID)
-	if err != nil || !processing {
+	if err != nil {
 		return err
 	}
+	if !processing {
+		return activityPubEventNotAppliedf("Move for account_id=%d is already being processed", actor.ID)
+	}
 	target, err := s.activityActorForMoveTargetURI(payload.Target)
-	if err != nil || target == nil || target.ID == 0 || target.SuspendedAt.Valid {
+	if err != nil {
 		s.unmarkActivityPubMoveAsProcessing(context.Background(), actor.ID)
 		return err
+	}
+	if target == nil || target.ID == 0 || target.SuspendedAt.Valid {
+		s.unmarkActivityPubMoveAsProcessing(context.Background(), actor.ID)
+		return activityPubEventNotAppliedf("Move target %q is unavailable", payload.Target)
 	}
 	if !stringArrayContains(target.AlsoKnownAs, sourceURI) {
 		s.unmarkActivityPubMoveAsProcessing(context.Background(), actor.ID)
-		return nil
+		return activityPubEventNotAppliedf("Move target does not reference source in alsoKnownAs")
 	}
 	if !(actor.MovedToAccountID.Valid && actor.MovedToAccountID.Int64 == target.ID) {
 		if err := s.setMovedToAccount(actor.ID, sql.NullInt64{Int64: target.ID, Valid: true}); err != nil {
@@ -1408,7 +1628,7 @@ const activityPubRedisLockDefaultTTL = 15 * time.Minute
 
 func (s *Server) activityActorForMoveTargetURI(actorURI string) (*models.Account, error) {
 	if s == nil || s.db == nil || strings.TrimSpace(actorURI) == "" {
-		return nil, nil
+		return nil, activityPubEventNotAppliedf("Move target URI is missing")
 	}
 	if s.localActivityURI(actorURI) {
 		return s.localAccountFromActivityURI(actorURI)
@@ -1417,11 +1637,14 @@ func (s *Server) activityActorForMoveTargetURI(actorURI string) (*models.Account
 		return nil, err
 	}
 	actor, err := s.fetchActivityActor(actorURI)
-	if err != nil || actor.ID == "" || actor.PublicKey.PublicKeyPem == "" {
-		return nil, nil
+	if err != nil {
+		return nil, err
+	}
+	if actor.ID == "" || actor.PublicKey.PublicKeyPem == "" {
+		return nil, activityPubEventNotAppliedf("Move target actor is missing id or public key")
 	}
 	if err := verifyRemoteActivityActorWebFinger(actor); err != nil {
-		return nil, nil
+		return nil, err
 	}
 	return s.upsertRemoteActivityActorForRequest(actor, "")
 }
@@ -1442,13 +1665,16 @@ func activityPubRedisLockKey(prefix string, name string) string {
 
 func (s *Server) markActivityPubDeleteUponArrival(actor *models.Account, uri string) error {
 	if s == nil || actor == nil || actor.ID == 0 {
-		return nil
+		return activityPubEventNotAppliedf("Delete arrival marker is missing a persisted actor")
+	}
+	if strings.TrimSpace(uri) == "" {
+		return activityPubEventNotAppliedf("Delete arrival marker is missing an activity URI")
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 	key := activityPubDeleteUponArrivalKey(redisConfig(s.cfg).prefix, actor.ID, uri)
-	_, _ = s.redisCommand(ctx, "SETEX", key, strconv.FormatInt(int64(activityPubDeleteUponArrivalTTL/time.Second), 10), "true")
-	return nil
+	_, err := s.redisCommand(ctx, "SETEX", key, strconv.FormatInt(int64(activityPubDeleteUponArrivalTTL/time.Second), 10), "true")
+	return err
 }
 
 func (s *Server) activityPubDeleteArrivedFirst(actor *models.Account, uri string) (bool, error) {
@@ -1460,7 +1686,7 @@ func (s *Server) activityPubDeleteArrivedFirst(actor *models.Account, uri string
 	key := activityPubDeleteUponArrivalKey(redisConfig(s.cfg).prefix, actor.ID, uri)
 	value, err := s.redisCommand(ctx, "EXISTS", key)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 	switch typed := value.(type) {
 	case int64:
@@ -1490,7 +1716,7 @@ func (s *Server) acquireActivityPubRedisLock(ctx context.Context, name string, t
 	key := activityPubRedisLockKey(redisConfig(s.cfg).prefix, name)
 	value, err := s.redisCommand(ctx, "SET", key, "true", "NX", "EX", strconv.FormatInt(int64(ttl/time.Second), 10))
 	if err != nil {
-		return true, release, nil
+		return false, release, err
 	}
 	if !strings.EqualFold(activityPubRedisString(value), "OK") {
 		return false, release, nil
@@ -1511,7 +1737,7 @@ func (s *Server) markActivityPubMoveAsProcessing(ctx context.Context, accountID 
 	defer cancel()
 	value, err := s.redisCommand(ctx, "SET", activityPubMoveProcessingKey(redisConfig(s.cfg).prefix, accountID), "true", "NX", "EX", strconv.FormatInt(int64(activityPubMoveProcessingCooldown/time.Second), 10))
 	if err != nil {
-		return true, nil
+		return false, err
 	}
 	return strings.EqualFold(activityPubRedisString(value), "OK"), nil
 }
@@ -1539,18 +1765,15 @@ func (s *Server) unmarkActivityPubMoveAsProcessing(ctx context.Context, accountI
 func (s *Server) processActivityPubCreateEncryptedMessage(payload activityPayload, actor *models.Account, target *models.Account) error {
 	object := payload.Object
 	if target == nil || target.ID == 0 || object.TargetDeviceID == "" {
-		return nil
+		return activityPubEventNotAppliedf("EncryptedMessage target account or device is missing")
 	}
 	if activityPubURIHostMismatch(actor.URI, object.ID) {
-		return nil
+		return activityPubEventNotAppliedf("EncryptedMessage object host does not match actor")
 	}
 	now := time.Now().UTC()
 	var targetDevice models.Device
 	if err := s.db.Where("account_id = ? AND device_id = ?", target.ID, object.TargetDeviceID).First(&targetDevice).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil
-		}
-		return err
+		return fmt.Errorf("load EncryptedMessage target device: %w", err)
 	}
 	messageFranking, err := s.cryptoMessageFrankingWithOriginal(actor.ID, target.ID, object.DigestValue, object.MessageFranking, now)
 	if err != nil {
@@ -1577,13 +1800,13 @@ func (s *Server) processActivityPubCreateEncryptedMessage(payload activityPayloa
 func (s *Server) processActivityPubCreateNote(payload activityPayload, actor *models.Account, deliveredTo *models.Account, relayedThrough *models.Account, options activityPubProcessingOptions) error {
 	note := payload.Object
 	if !activityNoteBelongsToActor(note, actor) {
-		return nil
+		return activityPubEventNotAppliedf("Create object does not belong to verified actor")
 	}
 	if !activityObjectIsStatus(note) {
-		return nil
+		return activityPubEventNotAppliedf("Create object is not a supported status")
 	}
 	if activityPubURIHostMismatch(actor.URI, note.ID) {
-		return nil
+		return activityPubEventNotAppliedf("Create object host does not match actor")
 	}
 	tombstoneExists, err := activityPubTombstoneExists(s.db, note.ID)
 	if err != nil || tombstoneExists {
@@ -1596,8 +1819,11 @@ func (s *Server) processActivityPubCreateNote(payload activityPayload, actor *mo
 		}
 	}
 	acquired, releaseCreateLock, err := s.acquireActivityPubRedisLock(context.Background(), "create:"+note.ID, activityPubRedisLockDefaultTTL)
-	if err != nil || !acquired {
+	if err != nil {
 		return err
+	}
+	if !acquired {
+		return activityPubEventNotAppliedf("Create object %q is already being processed", note.ID)
 	}
 	defer releaseCreateLock()
 	deleteArrivedFirst, err := s.activityPubDeleteArrivedFirst(actor, note.ID)
@@ -1606,6 +1832,9 @@ func (s *Server) processActivityPubCreateNote(payload activityPayload, actor *mo
 	}
 	now := time.Now().UTC()
 	handled, err := s.processActivityPubPollVote(note, actor, now)
+	if errors.Is(err, errActivityPubPollVoteAlreadyVoted) {
+		return nil
+	}
 	if err != nil || handled {
 		return err
 	}
@@ -2014,8 +2243,11 @@ func (s *Server) processActivityPubPollVote(note activityObject, actor *models.A
 
 	voteLockName := "vote:" + strconv.FormatInt(poll.ID, 10) + ":" + strconv.FormatInt(actor.ID, 10)
 	acquired, releaseVoteLock, err := s.acquireActivityPubRedisLock(context.Background(), voteLockName, activityPubRedisLockDefaultTTL)
-	if err != nil || !acquired {
+	if err != nil {
 		return true, err
+	}
+	if !acquired {
+		return true, activityPubEventNotAppliedf("poll vote for poll_id=%d account_id=%d is already being processed", poll.ID, actor.ID)
 	}
 	defer releaseVoteLock()
 
@@ -2079,10 +2311,10 @@ func (s *Server) processActivityPubUpdate(payload activityPayload, actor *models
 	if actorType := activityActorTypeValue(object.Types); actorType != "" {
 		object.Type = actorType
 		if object.ID == "" || actor.URI == "" || object.ID != actor.URI {
-			return nil
+			return activityPubEventNotAppliedf("Update actor object does not match verified actor")
 		}
 		if object.Inbox == "" || !activityPubHTTPURIAllowedRaw(object.ID) {
-			return nil
+			return activityPubEventNotAppliedf("Update actor object is missing a valid id or inbox")
 		}
 		if disallowed, err := s.remoteActivityDomainNotAllowed(object.ID); err != nil || disallowed {
 			return err
@@ -2094,10 +2326,10 @@ func (s *Server) processActivityPubUpdate(payload activityPayload, actor *models
 	}
 	if activityObjectIsStatus(object) {
 		if !activityNoteBelongsToActor(object, actor) {
-			return nil
+			return activityPubEventNotAppliedf("Update status does not belong to verified actor")
 		}
 		if activityPubURIHostMismatch(actor.URI, object.ID) {
-			return nil
+			return activityPubEventNotAppliedf("Update status host does not match actor")
 		}
 		var status models.Status
 		statusQuery := s.db.Where("uri = ? AND account_id = ?", object.ID, actor.ID)
@@ -2121,8 +2353,11 @@ func (s *Server) processActivityPubUpdate(payload activityPayload, actor *models
 			return nil
 		}
 		locked, releaseLock, err := s.acquireActivityPubRedisLock(context.Background(), "create:"+object.ID, activityPubRedisLockDefaultTTL)
-		if err != nil || !locked {
+		if err != nil {
 			return err
+		}
+		if !locked {
+			return activityPubEventNotAppliedf("Update object %q is already being processed", object.ID)
 		}
 		defer releaseLock()
 		if !activityPubStatusUpdateIsExplicit(status, editedAt) {
@@ -2238,7 +2473,7 @@ func (s *Server) processActivityPubUpdate(payload activityPayload, actor *models
 		}
 		return nil
 	}
-	return nil
+	return activityPubEventNotAppliedf("Update object type %q is unsupported", object.TypeExact)
 }
 
 // Mastodon 4.2.28 ignores old Update activities only when their object is not
@@ -2256,10 +2491,10 @@ func activityPubUpdateShouldIgnoreUnknownObject(statusMissing bool, object activ
 func (s *Server) processActivityPubDereferencedUpdate(payload activityPayload, actor *models.Account, deliveredTo *models.Account, relayedThrough *models.Account, options activityPubProcessingOptions) error {
 	objectFetchURI, objectURI := activityPubDereferenceFetchURI(payload.Object.ID)
 	if s == nil || actor == nil || objectFetchURI == "" || objectURI == "" {
-		return nil
+		return activityPubEventNotAppliedf("dereferenced Update has no fetchable object")
 	}
 	if activityPubURIHostMismatch(actor.URI, objectURI) {
-		return nil
+		return activityPubEventNotAppliedf("dereferenced Update object host does not match actor")
 	}
 	if disallowed, err := s.remoteActivityDomainNotAllowed(objectURI); err != nil || disallowed {
 		return err
@@ -2269,8 +2504,11 @@ func (s *Server) processActivityPubDereferencedUpdate(payload activityPayload, a
 		return err
 	}
 	object, err := s.fetchActivityObjectForUpdateWithFetchURI(objectFetchURI, objectURI, paonUserAgent(s.cfg), signer)
-	if err != nil || object.ID == "" {
-		return nil
+	if err != nil {
+		return err
+	}
+	if object.ID == "" {
+		return activityPubEventNotAppliedf("dereferenced Update object is missing id")
 	}
 	dereferenced := activityPubDereferencedUpdatePayload(payload, object)
 	return s.processActivityPubUpdate(dereferenced, actor, deliveredTo, relayedThrough, options)
@@ -2704,13 +2942,16 @@ func (s *Server) processActivityPubDelete(payload activityPayload, actor *models
 func (s *Server) processActivityPubDeleteWithContext(ctx context.Context, payload activityPayload, actor *models.Account) error {
 	target := payload.Object.ID
 	if target == "" && !payload.Object.Reference {
-		return nil
+		return activityPubEventNotAppliedf("Delete target is missing")
 	}
 	now := time.Now().UTC()
 	if actor.URI != "" && target == actor.URI {
 		acquired, releaseDeleteLock, err := s.acquireActivityPubRedisLock(ctx, "delete_in_progress:"+strconv.FormatInt(actor.ID, 10), 2*time.Hour)
-		if err != nil || !acquired {
+		if err != nil {
 			return err
+		}
+		if !acquired {
+			return activityPubEventNotAppliedf("actor Delete for account_id=%d is already being processed", actor.ID)
 		}
 		defer releaseDeleteLock()
 		if actor.Local() {
@@ -2733,8 +2974,11 @@ func (s *Server) processActivityPubDeleteWithContext(ctx context.Context, payloa
 		return nil
 	}
 	acquired, releaseDeleteLock, err := s.acquireActivityPubRedisLock(ctx, "delete_status_in_progress:"+target, activityPubRedisLockDefaultTTL)
-	if err != nil || !acquired {
+	if err != nil {
 		return err
+	}
+	if !acquired {
+		return activityPubEventNotAppliedf("status Delete for %q is already being processed", target)
 	}
 	defer releaseDeleteLock()
 	var status models.Status
@@ -2748,8 +2992,11 @@ func (s *Server) processActivityPubDeleteWithContext(ctx context.Context, payloa
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if activityPubURIHostsMatch(actor.URI, target) {
 			acquiredCreate, releaseCreateLock, err := s.acquireActivityPubRedisLock(ctx, "create:"+target, activityPubRedisLockDefaultTTL)
-			if err != nil || !acquiredCreate {
+			if err != nil {
 				return err
+			}
+			if !acquiredCreate {
+				return activityPubEventNotAppliedf("status %q is already being created", target)
 			}
 			defer releaseCreateLock()
 			if err := createActivityPubTombstone(tx, actor.ID, target, now); err != nil {
@@ -3730,14 +3977,17 @@ func (s *Server) scheduleActivityPubMentionRefreshIfStale(account *models.Accoun
 func (s *Server) fetchActivityPubMentionAccountByHref(tx *gorm.DB, href string) (*models.Account, error) {
 	actorURI := activityPubHTTPURI(href)
 	if s == nil || tx == nil || actorURI == "" {
-		return nil, nil
+		return nil, activityPubEventNotAppliedf("Mention href %q is not a fetchable actor URI", href)
 	}
 	if disallowed, err := s.remoteActivityDomainNotAllowed(actorURI); err != nil || disallowed {
 		return nil, err
 	}
 	actor, err := s.fetchActivityActor(actorURI)
-	if err != nil || actor.ID == "" {
-		return nil, nil
+	if err != nil {
+		return nil, err
+	}
+	if actor.ID == "" {
+		return nil, activityPubEventNotAppliedf("Mention actor %q is missing id", actorURI)
 	}
 	return s.upsertRemoteActivityActorDB(tx, actor)
 }
@@ -4207,8 +4457,11 @@ func updateReplyCountersAfterChange(tx *gorm.DB, oldReply sql.NullInt64, nextRep
 
 func (s *Server) updateActivityPubActor(actor *models.Account, object activityObject, requestID string) error {
 	acquired, releaseAccountLock, err := s.acquireActivityPubRedisLock(context.Background(), "process_account:"+object.ID, activityPubRedisLockDefaultTTL)
-	if err != nil || !acquired {
+	if err != nil {
 		return err
+	}
+	if !acquired {
+		return activityPubEventNotAppliedf("actor Update for %q is already being processed", object.ID)
 	}
 	defer releaseAccountLock()
 	now := time.Now().UTC()
@@ -4359,11 +4612,14 @@ func clearActivityPubActorHeaderMediaUpdates(updates map[string]any) {
 func (s *Server) processActivityPubFollow(payload activityPayload, actor *models.Account) error {
 	activityID := activityPayloadIDValueOrID(payload)
 	target, err := s.localAccountFromActivityURI(payload.Object.ID)
-	if err != nil || target == nil {
-		return nil
+	if err != nil {
+		return err
+	}
+	if target == nil {
+		return activityPubEventNotAppliedf("Follow target %q is not a known local account", payload.Object.ID)
 	}
 	if target.ID == actor.ID || !target.Local() {
-		return nil
+		return activityPubEventNotAppliedf("Follow target %q is not a distinct local account", payload.Object.ID)
 	}
 	if activityID != "" {
 		deleteArrivedFirst, err := s.activityPubDeleteArrivedFirst(actor, activityID)
@@ -4384,8 +4640,7 @@ func (s *Server) processActivityPubFollow(payload activityPayload, actor *models
 		return err
 	}
 	if rejected {
-		_ = s.deliverActivityPubFollowResponse("Reject", *target, *actor, 0, activityID)
-		return nil
+		return s.deliverActivityPubFollowResponse("Reject", *target, *actor, 0, activityID)
 	}
 	followURI := activityID
 	if !payload.IDPresent {
@@ -4461,7 +4716,9 @@ func (s *Server) processActivityPubFollow(payload activityPayload, actor *models
 			s.invalidateFollowRelationshipCaches(context.Background(), *actor, target.ID)
 			s.meiliReindexPrivateStatusesForAccountsBestEffort(context.Background(), target.ID)
 		}
-		_ = s.deliverActivityPubFollowResponse("Accept", *target, *actor, acceptResponseFollowID, string(accepted.URI))
+		if err := s.deliverActivityPubFollowResponse("Accept", *target, *actor, acceptResponseFollowID, string(accepted.URI)); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -4593,7 +4850,10 @@ func (s *Server) followTargetFromURI(uri string, accountID int64) (*models.Accou
 func (s *Server) processActivityPubLike(payload activityPayload, actor *models.Account) error {
 	activityID := activityPayloadIDValueOrID(payload)
 	status, err := s.localStatusFromActivityURI(activityPubLikeTargetURI(payload.Object))
-	if err != nil || status == nil {
+	if err != nil {
+		return err
+	}
+	if status == nil {
 		return nil
 	}
 	if status.AccountID == actor.ID || status.DeletedAt.Valid {
@@ -4642,7 +4902,10 @@ func (s *Server) processActivityPubLike(payload activityPayload, actor *models.A
 
 func (s *Server) processActivityPubUndoLike(object activityObject, actor *models.Account) error {
 	status, err := s.localStatusFromActivityURI(activityPubUndoLikeTargetURI(object))
-	if err != nil || status == nil {
+	if err != nil {
+		return err
+	}
+	if status == nil {
 		return nil
 	}
 	joinStatus := statusJoinTarget(status)
@@ -4695,12 +4958,15 @@ func (s *Server) processActivityPubAnnounce(payload activityPayload, actor *mode
 	targetURI := payload.Object.ID
 	lockTargetURI := activityPubAnnounceLockTargetURI(payload, targetURI)
 	if lockTargetURI == "" {
-		return nil
+		return activityPubEventNotAppliedf("Announce target is missing")
 	}
 	announceURI := activityAnnounceURI(activityPayloadIDValueOrID(payload), actor, targetURI)
 	acquired, releaseAnnounceLock, err := s.acquireActivityPubRedisLock(context.Background(), "announce:"+lockTargetURI, activityPubRedisLockDefaultTTL)
-	if err != nil || !acquired {
+	if err != nil {
 		return err
+	}
+	if !acquired {
+		return activityPubEventNotAppliedf("Announce target %q is already being processed", lockTargetURI)
 	}
 	defer releaseAnnounceLock()
 	if announceURI != "" {
@@ -4733,7 +4999,13 @@ func (s *Server) processActivityPubAnnounce(payload activityPayload, actor *mode
 		}
 		target, err = s.fetchActivityPubAnnounceTarget(targetURI, payload.Object.URL, payload.ID)
 	}
-	if err != nil || target == nil || target.DeletedAt.Valid {
+	if err != nil {
+		return err
+	}
+	if target == nil {
+		return activityPubEventNotAppliedf("Announce target %q could not be resolved", targetURI)
+	}
+	if target.DeletedAt.Valid {
 		return nil
 	}
 	related, err := s.activityPubAnnounceRelatedToLocalActivity(actor, relayedThrough, *target)
@@ -4911,7 +5183,7 @@ func (s *Server) processActivityPubUndoAnnounce(object activityObject, actor *mo
 func (s *Server) processActivityPubUndoAnnounceWithTombstone(object activityObject, actor *models.Account, tombstoneOnMiss bool) (bool, error) {
 	target, err := s.statusFromActivityURI(object.ObjectID)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 	announceURI := object.ID
 	var reblog models.Status

--- a/internal/paon/api/activitypub_inbox_test.go
+++ b/internal/paon/api/activitypub_inbox_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"database/sql"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -13,7 +14,72 @@ import (
 
 	"github.com/mstdn-plusminus-io/paon/internal/paon/config"
 	"github.com/mstdn-plusminus-io/paon/internal/paon/models"
+	"gorm.io/gorm"
 )
+
+func TestActivityPubProcessingFailuresReturnForAsynqRetry(t *testing.T) {
+	server := &Server{db: &gorm.DB{}}
+	actor := &models.Account{
+		ID:     42,
+		URI:    "https://remote.example/users/alice",
+		Domain: sql.NullString{String: "remote.example", Valid: true},
+	}
+	for _, test := range []struct {
+		name string
+		body string
+	}{
+		{name: "invalid JSON", body: `{`},
+		{name: "unsupported context", body: `{"type":"Create"}`},
+		{name: "verified actor mismatch", body: `{
+			"@context":"https://www.w3.org/ns/activitystreams",
+			"id":"https://other.example/activities/1",
+			"type":"Delete",
+			"actor":"https://other.example/users/bob",
+			"object":"https://other.example/users/bob"
+		}`},
+		{name: "unsupported activity", body: `{
+			"@context":"https://www.w3.org/ns/activitystreams",
+			"id":"https://remote.example/activities/1",
+			"type":"Travel",
+			"actor":"https://remote.example/users/alice",
+			"object":"https://remote.example/objects/1"
+		}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := server.processActivityPubInboxForDeliveredToWithContext(t.Context(), []byte(test.body), actor, nil, 0)
+			if !errors.Is(err, errActivityPubEventNotApplied) {
+				t.Fatalf("processing error = %v, want errActivityPubEventNotApplied", err)
+			}
+		})
+	}
+}
+
+func TestAcceptFollowPayloadPreservesEmbeddedFollowIdentity(t *testing.T) {
+	payload, err := parseActivityPayload([]byte(`{
+		"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/security/v1"],
+		"id":"https://remote.example/activities/accept-follow",
+		"type":"Accept",
+		"actor":"https://remote.example/users/bob",
+		"object":{
+			"id":"https://paon.example/payloads/original-follow",
+			"type":"Follow",
+			"actor":"https://paon.example/users/alice",
+			"object":"https://remote.example/users/bob"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload.Type != "Accept" || payload.Actor != "https://remote.example/users/bob" {
+		t.Fatalf("Accept identity = type %q actor %q", payload.Type, payload.Actor)
+	}
+	if payload.Object.TypeExact != "Follow" ||
+		payload.Object.ID != "https://paon.example/payloads/original-follow" ||
+		payload.Object.Actor != "https://paon.example/users/alice" ||
+		payload.Object.ObjectID != "https://remote.example/users/bob" {
+		t.Fatalf("embedded Follow = %#v", payload.Object)
+	}
+}
 
 func TestActivityPubNoteParsesRepliesCollection(t *testing.T) {
 	payload, err := parseActivityPayload([]byte(`{
@@ -587,7 +653,7 @@ func TestActivityPubPollVoteChoiceMatchesOptionExactly(t *testing.T) {
 	}
 }
 
-func TestActivityPubDereferenceRejectsMismatchedObjectHostBeforeFetchLikeRails(t *testing.T) {
+func TestActivityPubDereferenceReturnsMismatchedObjectHostForAsynqArchive(t *testing.T) {
 	oldClient := activityHTTPClient
 	defer func() { activityHTTPClient = oldClient }()
 	activityHTTPClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -598,20 +664,20 @@ func TestActivityPubDereferenceRejectsMismatchedObjectHostBeforeFetchLikeRails(t
 	server := &Server{cfg: config.Config{LocalDomain: "example.com", WebDomain: "example.com"}}
 	actor := &models.Account{URI: "https://remote.example/users/alice"}
 	createPayload := activityPayload{Type: "Create", Actor: actor.URI, Object: activityObject{ID: "https://evil.example/statuses/1"}}
-	if err := server.processActivityPubDereferencedCreate(createPayload, actor, nil, nil, activityPubProcessingOptions{}); err != nil {
+	if err := server.processActivityPubDereferencedCreate(createPayload, actor, nil, nil, activityPubProcessingOptions{}); !errors.Is(err, errActivityPubEventNotApplied) {
 		t.Fatalf("processActivityPubDereferencedCreate error = %v", err)
 	}
 	updatePayload := activityPayload{Type: "Update", Actor: actor.URI, Object: activityObject{ID: "https://evil.example/statuses/1"}}
-	if err := server.processActivityPubDereferencedUpdate(updatePayload, actor, nil, nil, activityPubProcessingOptions{}); err != nil {
+	if err := server.processActivityPubDereferencedUpdate(updatePayload, actor, nil, nil, activityPubProcessingOptions{}); !errors.Is(err, errActivityPubEventNotApplied) {
 		t.Fatalf("processActivityPubDereferencedUpdate error = %v", err)
 	}
 	bearcap := "bear:?u=https%3A%2F%2Fevil.example%2Fstatuses%2Fbear&t=secret-token"
 	bearcapCreate := activityPayload{Type: "Create", Actor: actor.URI, Object: activityObject{ID: bearcap}}
-	if err := server.processActivityPubDereferencedCreate(bearcapCreate, actor, nil, nil, activityPubProcessingOptions{}); err != nil {
+	if err := server.processActivityPubDereferencedCreate(bearcapCreate, actor, nil, nil, activityPubProcessingOptions{}); !errors.Is(err, errActivityPubEventNotApplied) {
 		t.Fatalf("processActivityPubDereferencedCreate bearcap error = %v", err)
 	}
 	bearcapUpdate := activityPayload{Type: "Update", Actor: actor.URI, Object: activityObject{ID: bearcap}}
-	if err := server.processActivityPubDereferencedUpdate(bearcapUpdate, actor, nil, nil, activityPubProcessingOptions{}); err != nil {
+	if err := server.processActivityPubDereferencedUpdate(bearcapUpdate, actor, nil, nil, activityPubProcessingOptions{}); !errors.Is(err, errActivityPubEventNotApplied) {
 		t.Fatalf("processActivityPubDereferencedUpdate bearcap error = %v", err)
 	}
 }

--- a/internal/paon/api/activitypub_observability.go
+++ b/internal/paon/api/activitypub_observability.go
@@ -127,7 +127,7 @@ func activityPubProcessingError(body []byte, actorID int64, deliveredTo int64, e
 
 func logActivityPubUnsupportedPayload(payload activityPayload, actorID int64, reason string) {
 	fields := activityPubLogFieldsFromPayload(payload)
-	log.Printf("activitypub processing ignored reason=%q actor_id=%d activity_type=%q activity_id=%q actor=%q object_type=%q object=%q",
+	log.Printf("activitypub processing rejected reason=%q actor_id=%d activity_type=%q activity_id=%q actor=%q object_type=%q object=%q",
 		reason, actorID, fields.Type, fields.ID, fields.Actor, activityPubSafeLogValue(payload.Object.TypeExact, activityPubLogValueLimit), fields.Object)
 }
 

--- a/internal/paon/api/activitypub_retry.go
+++ b/internal/paon/api/activitypub_retry.go
@@ -18,9 +18,8 @@ const activityPubDeliveryRetryKey = "paon:activitypub:delivery:retry"
 const activityPubDeliveryRetryFailureThreshold = 16
 
 // Inbound activity processing mirrors Rails ActivityPub::ProcessingWorker (Sidekiq
-// queue "ingress", retry 8). The inbox enqueues a job after signature verification and
-// returns 202 once a backend accepts it; a background worker re-fetches the actor and runs
-// processActivityPubInboxForTarget, re-enqueuing on failure up to the retry limit.
+// queue "ingress", retry 8). The inbox returns 202 only after Asynq accepts the task.
+// Every processing error is returned to Asynq so retry exhaustion archives the payload.
 const activityPubInboxProcessingRetryKey = "paon:activitypub:ingress:retry"
 const activityPubInboxProcessingRetryLimit = 8
 
@@ -34,9 +33,6 @@ type activityPubInboxProcessingJob struct {
 }
 
 func (s *Server) enqueueActivityPubInboxProcessingJob(actorID, deliveredTo int64, actorType string, body []byte) error {
-	if s == nil || s.db == nil || actorID == 0 || len(body) == 0 {
-		return nil
-	}
 	job := activityPubInboxProcessingJob{
 		ActorID:              actorID,
 		DeliveredToAccountID: deliveredTo,
@@ -45,52 +41,23 @@ func (s *Server) enqueueActivityPubInboxProcessingJob(actorID, deliveredTo int64
 		Attempts:             0,
 		CreatedAt:            time.Now().UTC().Unix(),
 	}
-	return enqueueActivityPubInboxProcessingJobWithBackends(
-		context.Background(),
-		job,
-		s.enqueueActivityPubProcessingTask,
-		s.enqueueActivityPubInboxProcessingJobRetry,
-	)
+	if s == nil {
+		return errors.New("activitypub inbox processing Asynq backend unavailable")
+	}
+	return enqueueActivityPubInboxProcessingJobWithAsynq(job, s.enqueueActivityPubProcessingTask)
 }
 
-func enqueueActivityPubInboxProcessingJobWithBackends(
-	ctx context.Context,
+func enqueueActivityPubInboxProcessingJobWithAsynq(
 	job activityPubInboxProcessingJob,
 	enqueueAsynq func(activityPubInboxProcessingJob) bool,
-	enqueueFallback func(context.Context, activityPubInboxProcessingJob) error,
 ) error {
 	if job.ActorID == 0 || len(job.Body) == 0 {
-		return nil
+		return errors.New("activitypub inbox processing task is missing actor or body")
 	}
 	if enqueueAsynq != nil && enqueueAsynq(job) {
 		return nil
 	}
-	if enqueueFallback == nil {
-		return errors.New("activitypub inbox processing fallback enqueue unavailable")
-	}
-	if err := enqueueFallback(ctx, job); err != nil {
-		return fmt.Errorf("enqueue activitypub inbox processing fallback: %w", err)
-	}
-	return nil
-}
-
-func (s *Server) enqueueActivityPubInboxProcessingJobRetry(ctx context.Context, job activityPubInboxProcessingJob) error {
-	if job.ActorID == 0 || len(job.Body) == 0 {
-		return nil
-	}
-	encoded, runAt, err := nextActivityPubInboxRetry(job, time.Now().UTC())
-	if err != nil {
-		return err
-	}
-	_, err = s.redisCommand(ctx, "ZADD", redisConfig(s.cfg).prefix+activityPubInboxProcessingRetryKey, strconv.FormatInt(runAt.Unix(), 10), encoded)
-	return err
-}
-
-func nextActivityPubInboxRetry(job activityPubInboxProcessingJob, now time.Time) (string, time.Time, error) {
-	job.Attempts++
-	runAt := now.UTC().Add(activityPubDeliveryRetryDelay(job.Attempts))
-	encoded, err := json.Marshal(job)
-	return string(encoded), runAt, err
+	return errors.New("activitypub inbox processing Asynq enqueue failed")
 }
 
 func (s *Server) runActivityPubInboxProcessingWorker(ctx context.Context) {
@@ -120,58 +87,27 @@ func (s *Server) processDueActivityPubInboxProcessingJobs(ctx context.Context, l
 	for _, claim := range claims {
 		var job activityPubInboxProcessingJob
 		if err := json.Unmarshal([]byte(claim.Member), &job); err != nil {
+			continue
+		}
+		if s.enqueueActivityPubProcessingTask(job) {
 			_ = s.acknowledgeRedisRetryJob(ctx, key, claim)
-			continue
 		}
-		if err := s.performActivityPubInboxProcessingOnce(ctx, job); err == nil || job.Attempts >= activityPubInboxProcessingRetryLimit {
-			_ = s.acknowledgeRedisRetryJob(ctx, key, claim)
-			continue
-		}
-		successor, runAt, err := nextActivityPubInboxRetry(job, now)
-		if err != nil {
-			continue
-		}
-		_ = s.replaceRedisRetryJob(ctx, key, claim, successor, runAt)
-	}
-}
-
-func (s *Server) performActivityPubInboxProcessing(ctx context.Context, job activityPubInboxProcessingJob) {
-	if err := s.performActivityPubInboxProcessingOnce(ctx, job); err != nil {
-		s.reenqueueActivityPubInboxProcessing(ctx, job)
 	}
 }
 
 func (s *Server) performActivityPubInboxProcessingOnce(ctx context.Context, job activityPubInboxProcessingJob) error {
 	if job.ActorType != "" && job.ActorType != "Account" {
-		return nil
+		return activityPubProcessingError(job.Body, job.ActorID, job.DeliveredToAccountID, fmt.Errorf("unsupported actor type %q", job.ActorType))
 	}
-	if s.db == nil {
-		return nil
+	if s == nil || s.db == nil {
+		return activityPubProcessingError(job.Body, job.ActorID, job.DeliveredToAccountID, errors.New("database is unavailable"))
 	}
 	var actor models.Account
 	if err := s.db.WithContext(ctx).Where("id = ?", job.ActorID).First(&actor).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil
-		}
-		return err
+		return activityPubProcessingError(job.Body, job.ActorID, job.DeliveredToAccountID, fmt.Errorf("load verified actor: %w", err))
 	}
 	err := s.processActivityPubInboxForDeliveredToWithContext(ctx, job.Body, &actor, nil, job.DeliveredToAccountID)
-	if activityPubInboxPermanentValidationError(err) {
-		logActivityPubProcessingIssue("rejected", "permanent_validation_error", job.Body, actor.ID, job.DeliveredToAccountID, err)
-		return nil
-	}
 	return activityPubProcessingError(job.Body, actor.ID, job.DeliveredToAccountID, err)
-}
-
-func activityPubInboxPermanentValidationError(err error) bool {
-	return errors.Is(err, errFeaturedTagInvalidName) || errors.Is(err, errFeaturedTagLimit) || errors.Is(err, errFeaturedTagDuplicate)
-}
-
-func (s *Server) reenqueueActivityPubInboxProcessing(ctx context.Context, job activityPubInboxProcessingJob) {
-	if job.Attempts >= activityPubInboxProcessingRetryLimit {
-		return
-	}
-	_ = s.enqueueActivityPubInboxProcessingJobRetry(ctx, job)
 }
 
 type activityPubDeliveryRetryJob struct {

--- a/internal/paon/api/activitypub_retry_test.go
+++ b/internal/paon/api/activitypub_retry_test.go
@@ -1,29 +1,23 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
 	"os"
 	"strings"
 	"testing"
 	"time"
-
-	"gorm.io/gorm"
 )
 
-func TestEnqueueActivityPubInboxProcessingJobBackendBoundaries(t *testing.T) {
+func TestEnqueueActivityPubInboxProcessingJobRequiresAsynq(t *testing.T) {
 	job := activityPubInboxProcessingJob{
 		ActorID:   42,
 		ActorType: "Account",
 		Body:      json.RawMessage(`{"type":"Create"}`),
 	}
 
-	t.Run("asynq success skips fallback", func(t *testing.T) {
+	t.Run("accepted", func(t *testing.T) {
 		asynqCalled := false
-		fallbackCalled := false
-		err := enqueueActivityPubInboxProcessingJobWithBackends(
-			context.Background(),
+		err := enqueueActivityPubInboxProcessingJobWithAsynq(
 			job,
 			func(got activityPubInboxProcessingJob) bool {
 				asynqCalled = true
@@ -32,63 +26,24 @@ func TestEnqueueActivityPubInboxProcessingJobBackendBoundaries(t *testing.T) {
 				}
 				return true
 			},
-			func(context.Context, activityPubInboxProcessingJob) error {
-				fallbackCalled = true
-				return nil
-			},
 		)
 		if err != nil {
 			t.Fatalf("enqueue error = %v", err)
 		}
-		if !asynqCalled || fallbackCalled {
-			t.Fatalf("asynqCalled=%t fallbackCalled=%t", asynqCalled, fallbackCalled)
+		if !asynqCalled {
+			t.Fatal("Asynq backend was not called")
 		}
 	})
 
-	t.Run("fallback success is accepted", func(t *testing.T) {
-		fallbackCalled := false
-		err := enqueueActivityPubInboxProcessingJobWithBackends(
-			context.Background(),
+	t.Run("enqueue failure is returned", func(t *testing.T) {
+		err := enqueueActivityPubInboxProcessingJobWithAsynq(
 			job,
 			func(activityPubInboxProcessingJob) bool { return false },
-			func(_ context.Context, got activityPubInboxProcessingJob) error {
-				fallbackCalled = true
-				if got.ActorID != job.ActorID || string(got.Body) != string(job.Body) {
-					t.Fatalf("fallback job = %#v, want %#v", got, job)
-				}
-				return nil
-			},
 		)
-		if err != nil {
+		if err == nil || !strings.Contains(err.Error(), "Asynq enqueue failed") {
 			t.Fatalf("enqueue error = %v", err)
 		}
-		if !fallbackCalled {
-			t.Fatal("fallback was not called after asynq rejected the job")
-		}
 	})
-
-	t.Run("both backends fail", func(t *testing.T) {
-		fallbackErr := errors.New("redis zadd failed")
-		err := enqueueActivityPubInboxProcessingJobWithBackends(
-			context.Background(),
-			job,
-			func(activityPubInboxProcessingJob) bool { return false },
-			func(context.Context, activityPubInboxProcessingJob) error { return fallbackErr },
-		)
-		if !errors.Is(err, fallbackErr) {
-			t.Fatalf("enqueue error = %v, want wrapped fallback error", err)
-		}
-	})
-}
-
-func TestEnqueueActivityPubInboxProcessingJobNoopInputs(t *testing.T) {
-	var nilServer *Server
-	if err := nilServer.enqueueActivityPubInboxProcessingJob(42, 0, "Account", []byte(`{"type":"Create"}`)); err != nil {
-		t.Fatalf("nil server no-op error = %v", err)
-	}
-	if err := (&Server{}).enqueueActivityPubInboxProcessingJob(42, 0, "Account", []byte(`{"type":"Create"}`)); err != nil {
-		t.Fatalf("missing database no-op error = %v", err)
-	}
 
 	for name, job := range map[string]activityPubInboxProcessingJob{
 		"missing actor": {Body: json.RawMessage(`{"type":"Create"}`)},
@@ -96,14 +51,12 @@ func TestEnqueueActivityPubInboxProcessingJobNoopInputs(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			calls := 0
-			err := enqueueActivityPubInboxProcessingJobWithBackends(
-				context.Background(),
+			err := enqueueActivityPubInboxProcessingJobWithAsynq(
 				job,
 				func(activityPubInboxProcessingJob) bool { calls++; return true },
-				func(context.Context, activityPubInboxProcessingJob) error { calls++; return nil },
 			)
-			if err != nil {
-				t.Fatalf("no-op enqueue error = %v", err)
+			if err == nil {
+				t.Fatal("invalid task was accepted")
 			}
 			if calls != 0 {
 				t.Fatalf("backend calls = %d, want 0", calls)
@@ -112,15 +65,10 @@ func TestEnqueueActivityPubInboxProcessingJobNoopInputs(t *testing.T) {
 	}
 }
 
-func TestActivityPubInboxProcessingWorkerIgnoresUnsupportedActorTypeLikeRails(t *testing.T) {
-	server := &Server{db: &gorm.DB{}}
-	job := activityPubInboxProcessingJob{
-		ActorID:   123,
-		ActorType: "InstanceActor",
-		Body:      json.RawMessage(`{"type":"Delete"}`),
-	}
-	if err := server.performActivityPubInboxProcessingOnce(context.Background(), job); err != nil {
-		t.Fatalf("unsupported actor_type should be ignored like Rails, got error: %v", err)
+func TestEnqueueActivityPubInboxProcessingJobRejectsUnavailableServer(t *testing.T) {
+	var server *Server
+	if err := server.enqueueActivityPubInboxProcessingJob(42, 0, "Account", []byte(`{"type":"Create"}`)); err == nil {
+		t.Fatal("missing Asynq backend was accepted")
 	}
 }
 

--- a/internal/paon/api/asynq_workers.go
+++ b/internal/paon/api/asynq_workers.go
@@ -1735,8 +1735,8 @@ func (s *Server) enqueueFollowersSynchronizationTask(accountID int64, collection
 }
 
 // enqueueActivityPubProcessingTask mirrors ActivityPub::ProcessingWorker.perform_async
-// on Rails' ingress queue. The older Redis ZSET processing queue remains the fallback
-// when asynq is unavailable.
+// on Rails' ingress queue. Processing errors must remain on this Asynq path so retry
+// exhaustion preserves the failed event in the archive.
 func (s *Server) enqueueActivityPubProcessingTask(job activityPubInboxProcessingJob) bool {
 	if s == nil || s.asynqClient == nil || job.ActorID == 0 || len(job.Body) == 0 {
 		return false
@@ -1780,7 +1780,8 @@ func railsExponentialBackoffAsynqTask(task *asynq.Task) bool {
 		return false
 	}
 	switch task.Type() {
-	case asynqTaskRedownloadAvatar,
+	case asynqTaskActivityPubProcessing,
+		asynqTaskRedownloadAvatar,
 		asynqTaskRedownloadHeader,
 		asynqTaskRedownloadMedia,
 		asynqTaskFetchReply,
@@ -3176,8 +3177,11 @@ func (s *Server) handleAsynqActivityPubProcessing(ctx context.Context, t *asynq.
 	if err := json.Unmarshal(t.Payload(), &job); err != nil {
 		return fmt.Errorf("activitypub processing: %w", err)
 	}
-	if s == nil || s.db == nil || job.ActorID == 0 || len(job.Body) == 0 {
-		return nil
+	if s == nil || s.db == nil {
+		return errors.New("activitypub processing: database is unavailable")
+	}
+	if job.ActorID == 0 || len(job.Body) == 0 {
+		return activityPubProcessingError(job.Body, job.ActorID, job.DeliveredToAccountID, errors.New("task is missing actor or body"))
 	}
 	return s.performActivityPubInboxProcessingOnce(ctx, job)
 }

--- a/internal/paon/api/asynq_workers_test.go
+++ b/internal/paon/api/asynq_workers_test.go
@@ -40,6 +40,13 @@ func TestActivityFetchWorkerErrorMatchesRailsRetryPolicy(t *testing.T) {
 	}
 }
 
+func TestActivityPubProcessingUsesRailsRetryBackoff(t *testing.T) {
+	task := asynq.NewTask(asynqTaskActivityPubProcessing, nil)
+	if !railsExponentialBackoffAsynqTask(task) {
+		t.Fatal("ActivityPub processing must use the Sidekiq-compatible retry schedule")
+	}
+}
+
 func TestRemoteFetchWorkersApplyRailsUnsalvageableResponsePolicy(t *testing.T) {
 	src, err := os.ReadFile("asynq_workers.go")
 	if err != nil {

--- a/internal/paon/api/background_worker_semantics.go
+++ b/internal/paon/api/background_worker_semantics.go
@@ -21,7 +21,7 @@ var backgroundWorkerConcurrencyInventory = map[string]backgroundWorkerSemantics{
 	"syncMeiliIndexesBestEffort":          {Concurrency: backgroundWorkerSingleton, Proof: "scheduler cadence marker"},
 	"runStatsDInformantWorker":            {Concurrency: backgroundWorkerDuplicateSafe, Proof: "per-process metrics"},
 	"runActivityPubDeliveryRetryWorker":   {Concurrency: backgroundWorkerQueueConsumer, Proof: "Redis visibility lease and owner-fenced ack"},
-	"runActivityPubInboxProcessingWorker": {Concurrency: backgroundWorkerQueueConsumer, Proof: "Redis visibility lease and owner-fenced ack"},
+	"runActivityPubInboxProcessingWorker": {Concurrency: backgroundWorkerQueueConsumer, Proof: "legacy Redis queue migration into Asynq with owner-fenced ack"},
 	"startAsynqWorker":                    {Concurrency: backgroundWorkerQueueConsumer, Proof: "Asynq reservation and retry"},
 	"runWebhookDeliveryRetryWorker":       {Concurrency: backgroundWorkerQueueConsumer, Proof: "Redis visibility lease and owner-fenced ack"},
 	"runWebPushDeliveryRetryWorker":       {Concurrency: backgroundWorkerQueueConsumer, Proof: "Redis visibility lease and owner-fenced ack"},

--- a/internal/paon/api/worker_reliability_test.go
+++ b/internal/paon/api/worker_reliability_test.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/hibiken/asynq"
 	"gorm.io/gorm"
@@ -59,28 +59,23 @@ func TestRedisRetryLeaseScriptsRequireClaimOwnership(t *testing.T) {
 	}
 }
 
-func TestRedisRetrySuccessorsIncrementAttemptsWithoutMutatingCurrentClaim(t *testing.T) {
-	now := time.Unix(1_800_000_000, 0).UTC()
-	job := activityPubInboxProcessingJob{ActorID: 1, Body: []byte(`{"type":"Create"}`), Attempts: 2}
-	encoded, runAt, err := nextActivityPubInboxRetry(job, now)
+func TestActivityPubProcessingFailuresRemainOnAsynqRetryPath(t *testing.T) {
+	retrySource, err := os.ReadFile("activitypub_retry.go")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if job.Attempts != 2 {
-		t.Fatalf("current claim was mutated: attempts=%d", job.Attempts)
+	if strings.Contains(string(retrySource), "activityPubInboxPermanentValidationError") {
+		t.Fatal("ActivityPub processing still discards handler errors before Asynq can retry and archive them")
 	}
-	if !strings.Contains(encoded, `"attempts":3`) || !runAt.After(now) {
-		t.Fatalf("successor = %s runAt=%s", encoded, runAt)
+	if !strings.Contains(string(retrySource), "return activityPubProcessingError(job.Body, actor.ID, job.DeliveredToAccountID, err)") {
+		t.Fatal("ActivityPub processing does not return handler errors to Asynq")
 	}
-}
 
-func TestActivityPubInboxValidationClassificationKeepsDatabaseFailuresRetryable(t *testing.T) {
-	for _, err := range []error{errFeaturedTagInvalidName, errFeaturedTagDuplicate, errFeaturedTagLimit} {
-		if !activityPubInboxPermanentValidationError(err) {
-			t.Fatalf("featured-tag validation error must be discarded: %v", err)
-		}
+	asynqSource, err := os.ReadFile("asynq_workers.go")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if activityPubInboxPermanentValidationError(errors.New("postgres serialization failure")) {
-		t.Fatal("transient database error was classified as permanent validation")
+	if !strings.Contains(string(asynqSource), "asynq.MaxRetry(activityPubInboxProcessingRetryLimit)") {
+		t.Fatal("ActivityPub processing task lacks the retry option required for eventual Asynq archival")
 	}
 }


### PR DESCRIPTION
Propagate rejected and processing errors instead of silently ignoring them or routing around Asynq, allowing failed activities to follow the retry and archive path. Also validate inbox targets and resolve Follow responses using embedded or delivered-to account identity, including shared inboxes.